### PR TITLE
feat(shell): improve help consistency and TAB completion

### DIFF
--- a/src/shell/completer.test.ts
+++ b/src/shell/completer.test.ts
@@ -238,4 +238,50 @@ describe('getCompletions', () => {
       expect(completions).toContain('my-connector');
     });
   });
+
+  describe('empty data provider responses', () => {
+    const emptyDataProvider: DynamicDataProvider = {
+      getConnectorIds: vi.fn(() => []),
+      getSessionPrefixes: vi.fn(() => []),
+      getRpcIds: vi.fn(() => []),
+    };
+
+    it('should handle empty connector list gracefully for cd', () => {
+      const context: ShellContext = {};
+      const [completions] = getCompletions('cd ', context, emptyDataProvider);
+
+      // Should still show navigation shortcuts
+      expect(completions).toContain('/');
+      expect(completions).toContain('..');
+      expect(completions).toContain('-');
+      expect(completions).toHaveLength(3);
+    });
+
+    it('should handle empty session list gracefully for show at connector level', () => {
+      const context: ShellContext = { connector: 'test-connector' };
+      const [completions] = getCompletions('show ', context, emptyDataProvider);
+
+      // Should still show --json option
+      expect(completions).toContain('--json');
+      expect(completions).toHaveLength(1);
+    });
+
+    it('should handle empty rpc list gracefully for show at session level', () => {
+      const context: ShellContext = { connector: 'test-connector', session: 'test-session' };
+      const [completions] = getCompletions('show ', context, emptyDataProvider);
+
+      // Should still show --json option
+      expect(completions).toContain('--json');
+      expect(completions).toHaveLength(1);
+    });
+
+    it('should handle empty connector list for use command', () => {
+      const context: ShellContext = {};
+      const [completions] = getCompletions('use ', context, emptyDataProvider);
+
+      // Should still show session keyword
+      expect(completions).toContain('session');
+      expect(completions).toHaveLength(1);
+    });
+  });
 });

--- a/src/shell/completer.ts
+++ b/src/shell/completer.ts
@@ -71,12 +71,12 @@ function getCandidates(
 
   // Handle router-style commands (cd, cc, ls, show, ..)
   if (ROUTER_COMMANDS.includes(firstToken)) {
-    return getRouterCompletions(firstToken, completedTokens, currentToken, context, dataProvider);
+    return getRouterCompletions(firstToken, completedTokens, context, dataProvider);
   }
 
   // Handle shell builtins
   if (SHELL_BUILTINS.includes(firstToken)) {
-    return getBuiltinCompletions(firstToken, completedTokens, currentToken, context, dataProvider);
+    return getBuiltinCompletions(firstToken, completedTokens, dataProvider);
   }
 
   // Handle command completions
@@ -106,7 +106,6 @@ function getContextLevel(context: ShellContext): 'root' | 'connector' | 'session
 function getRouterCompletions(
   command: string,
   tokens: string[],
-  _currentToken: string,
   context: ShellContext,
   dataProvider: DynamicDataProvider
 ): string[] {
@@ -174,8 +173,6 @@ function getRouterCompletions(
 function getBuiltinCompletions(
   command: string,
   tokens: string[],
-  _currentToken: string,
-  _context: ShellContext,
   dataProvider: DynamicDataProvider
 ): string[] {
   switch (command) {

--- a/src/shell/repl.ts
+++ b/src/shell/repl.ts
@@ -11,6 +11,7 @@ import {
   ROUTER_COMMANDS,
   BLOCKED_IN_SHELL,
   DEFAULT_COMPLETION_LIMIT,
+  SESSION_SEARCH_LIMIT,
   getAllowedCommands,
 } from './types.js';
 import { applyContext } from './context-applicator.js';
@@ -434,7 +435,7 @@ Tips:
       try {
         const manager = new ConfigManager(this.configPath);
         const store = new EventLineStore(manager.getConfigDir());
-        const sessions = store.getSessions(this.context.connector, 100);
+        const sessions = store.getSessions(this.context.connector, SESSION_SEARCH_LIMIT);
         const matches = sessions.filter(s => s.session_id.startsWith(prefix));
 
         if (matches.length === 0) {

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -133,6 +133,12 @@ export const BLOCKED_IN_SHELL = ['explore', 'e'];
 export const DEFAULT_COMPLETION_LIMIT = 50;
 
 /**
+ * Limit for session search when looking for matches by prefix
+ * Higher than completion limit since we need to find partial matches
+ */
+export const SESSION_SEARCH_LIMIT = 100;
+
+/**
  * Get commands allowed in shell mode (TOP_LEVEL_COMMANDS minus BLOCKED_IN_SHELL)
  */
 export function getAllowedCommands(): string[] {


### PR DESCRIPTION
## Summary

- **Shell help consistency**: Hide `explore`/`e` from help output (blocked in shell mode)
- **TAB completion enhancement**: Add context-aware dynamic data completion for navigation commands

## Changes

### Help Improvements
- `help` command no longer shows `explore`/`e` in the command listing
- `help explore` or `help e` now shows informative message about stdin conflict

### TAB Completion Enhancements

| Command | Before | After |
|---------|--------|-------|
| `cd <TAB>` | (no completion) | `/`, `..`, `-`, + connector IDs at root, session prefixes at connector level |
| `cc <TAB>` | (no completion) | Same as cd |
| `show <TAB>` | `--json` only | `--json` + context-aware targets (connectors/sessions/rpc IDs) |
| `ls <TAB>` | (no completion) | `-l`, `--long`, `--json`, `--ids` |
| `view <TAB>` | options only | options + connector IDs |
| `help <TAB>` | commands without router | commands including router commands |

### Context-Aware Completion Examples

**At root level (`proofscan:/`):**
```
proofscan:/$ cd <TAB>
/  ..  -  mcp-server  my-connector  test-conn

proofscan:/$ show <TAB>
--json  mcp-server  my-connector  test-conn
```

**At connector level (`proofscan:/mcp-server`):**
```
proofscan:/mcp-server$ cd <TAB>
/  ..  -  abc12345  def67890  xyz99999

proofscan:/mcp-server$ show <TAB>
--json  abc12345  def67890  xyz99999
```

**At session level (`proofscan:/mcp-server/abc12345`):**
```
proofscan:/mcp-server/abc12345$ show <TAB>
--json  1  2  3  (rpc IDs)
```

## Test Plan

- [x] All 362 tests pass (19 new tests added for completer)
- [x] `npm run build` succeeds
- [ ] Manual verification of TAB completion in shell mode
- [ ] Verify `help` output doesn't show explore/e
- [ ] Verify `help explore` shows blocked message

🤖 Generated with [Claude Code](https://claude.com/claude-code)