### PR TITLE
fix(dpapi): use -EncodedCommand for PowerShell scripts (v0.7.2)

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -238,6 +238,7 @@ Examples:
           secretize_output: [],
           secrets_stored: 0,
           placeholders_detected: 0,
+          storage_errors: 0,
         };
 
         // Process connectors
@@ -269,6 +270,7 @@ Examples:
                 if (secretizeResult) {
                   result.secrets_stored += secretizeResult.storedCount;
                   result.placeholders_detected += secretizeResult.placeholderCount;
+                  result.storage_errors += secretizeResult.errorCount;
                 }
               } else {
                 // Skipped: do NOT count secret refs (not actually saved)
@@ -284,6 +286,7 @@ Examples:
               if (secretizeResult) {
                 result.secrets_stored += secretizeResult.storedCount;
                 result.placeholders_detected += secretizeResult.placeholderCount;
+                result.storage_errors += secretizeResult.errorCount;
               }
             }
           }

--- a/src/config/add.ts
+++ b/src/config/add.ts
@@ -49,6 +49,8 @@ export interface AddResult {
   secrets_stored: number;
   /** Phase 3.5: Number of placeholders detected */
   placeholders_detected: number;
+  /** Phase 3.5.1: Number of storage errors (encryption failures) */
+  storage_errors: number;
 }
 
 // ============================================================

--- a/src/secrets/providers/dpapi.test.ts
+++ b/src/secrets/providers/dpapi.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for DPAPI provider utilities
+ *
+ * Note: Full DPAPI encrypt/decrypt tests require Windows.
+ * These tests focus on the encodePowerShellScript helper which works cross-platform.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { encodePowerShellScript } from './dpapi.js';
+
+describe('encodePowerShellScript', () => {
+  it('should encode a simple script to UTF-16LE base64', () => {
+    const script = 'echo "hello"';
+    const encoded = encodePowerShellScript(script);
+
+    // Decode and verify it's UTF-16LE
+    const decoded = Buffer.from(encoded, 'base64');
+
+    // UTF-16LE: each character is 2 bytes, little endian
+    expect(decoded.length).toBe(script.length * 2);
+
+    // Verify first character 'e' (0x0065 in little endian = 0x65, 0x00)
+    expect(decoded[0]).toBe(0x65); // 'e'
+    expect(decoded[1]).toBe(0x00);
+  });
+
+  it('should handle special characters correctly', () => {
+    const script = 'Write-Host "Test with $variable and (parentheses)"';
+    const encoded = encodePowerShellScript(script);
+
+    // Should not throw and should produce valid base64
+    expect(encoded).toMatch(/^[A-Za-z0-9+/]+=*$/);
+
+    // Verify we can decode it back
+    const decoded = Buffer.from(encoded, 'base64');
+    expect(decoded.length).toBe(script.length * 2);
+  });
+
+  it('should handle multi-line scripts', () => {
+    const script = `Add-Type -AssemblyName System.Security
+$bytes = [System.Convert]::FromBase64String("SGVsbG8=")
+[System.Convert]::ToBase64String($bytes)`;
+
+    const encoded = encodePowerShellScript(script);
+
+    // Should produce valid base64
+    expect(encoded).toMatch(/^[A-Za-z0-9+/]+=*$/);
+
+    // Decode and verify length
+    const decoded = Buffer.from(encoded, 'base64');
+    expect(decoded.length).toBe(script.length * 2);
+  });
+
+  it('should handle scripts with nested quotes', () => {
+    // This is the problematic case that caused the original bug
+    const base64Input = 'SGVsbG9Xb3JsZA=='; // "HelloWorld" in base64
+    const script = `$bytes = [System.Convert]::FromBase64String("${base64Input}")`;
+
+    const encoded = encodePowerShellScript(script);
+
+    // Should produce valid base64 without issues
+    expect(encoded).toMatch(/^[A-Za-z0-9+/]+=*$/);
+
+    // Verify the nested quotes are preserved
+    const decoded = Buffer.from(encoded, 'base64');
+    const decodedScript = decodeUtf16Le(decoded);
+    expect(decodedScript).toBe(script);
+    expect(decodedScript).toContain('"');
+    expect(decodedScript).toContain(base64Input);
+  });
+
+  it('should handle empty script', () => {
+    const script = '';
+    const encoded = encodePowerShellScript(script);
+    expect(encoded).toBe('');
+  });
+
+  it('should handle scripts with various special characters', () => {
+    const script = 'echo "quotes" \'single\' $var @() #{} | & ; < > !';
+    const encoded = encodePowerShellScript(script);
+
+    // Should produce valid base64
+    expect(encoded).toMatch(/^[A-Za-z0-9+/]+=*$/);
+
+    // Verify round-trip
+    const decoded = Buffer.from(encoded, 'base64');
+    const decodedScript = decodeUtf16Le(decoded);
+    expect(decodedScript).toBe(script);
+  });
+
+  it('should produce correct output for known input', () => {
+    // "Write-Output 'test'" in UTF-16LE base64
+    const script = 'Write-Output test';
+    const encoded = encodePowerShellScript(script);
+
+    // Verify we can decode it back correctly
+    const decoded = Buffer.from(encoded, 'base64');
+    const decodedScript = decodeUtf16Le(decoded);
+    expect(decodedScript).toBe(script);
+  });
+});
+
+/**
+ * Helper to decode UTF-16LE buffer to string
+ */
+function decodeUtf16Le(buffer: Buffer): string {
+  let result = '';
+  for (let i = 0; i < buffer.length; i += 2) {
+    const charCode = buffer.readUInt16LE(i);
+    result += String.fromCharCode(charCode);
+  }
+  return result;
+}

--- a/src/secrets/secretize.test.ts
+++ b/src/secrets/secretize.test.ts
@@ -301,4 +301,42 @@ describe('formatSecretizeOutput', () => {
     // Should show stored message
     expect(output.some(line => line.includes('secret stored'))).toBe(true);
   });
+
+  it('should format storage errors (v0.7.2)', () => {
+    const results = [
+      {
+        key: 'API_KEY',
+        originalValue: 'secret-value',
+        newValue: 'secret-value',
+        action: 'error' as const,
+        error: 'DPAPI encryption failed: PowerShell error',
+      },
+    ];
+
+    const output = formatSecretizeOutput(results, 'test');
+
+    expect(output.length).toBe(1);
+    expect(output[0]).toContain('✖ storage failed');
+    expect(output[0]).toContain('test.transport.env.API_KEY');
+    expect(output[0]).toContain('DPAPI encryption failed');
+  });
+
+  it('should format storage errors without message', () => {
+    const results = [
+      {
+        key: 'SECRET_TOKEN',
+        originalValue: 'secret-value',
+        newValue: 'secret-value',
+        action: 'error' as const,
+      },
+    ];
+
+    const output = formatSecretizeOutput(results, 'my-connector');
+
+    expect(output.length).toBe(1);
+    expect(output[0]).toContain('✖ storage failed');
+    expect(output[0]).toContain('my-connector.transport.env.SECRET_TOKEN');
+    // Should not have extra colon when no error message
+    expect(output[0]).not.toContain('::');
+  });
 });


### PR DESCRIPTION
## Summary

- Windows DPAPI暗号化/復号がPowerShellパーサーエラーで失敗する問題を修正
- `-Command` から `-EncodedCommand` に変更してクォート問題を回避
- 暗号化失敗時のエラーハンドリングを改善（placeholderと区別）

## Problem

DPAPI encryption/decryption was failing on Windows with:
```
MissingEndParenthesisInMethodCall
```

**Root Cause**: Nested double quotes in `-Command "... FromBase64String(\"BASE64\") ..."` caused PowerShell parser errors.

## Solution

Use `-EncodedCommand` instead of `-Command`:
1. Added `encodePowerShellScript()` helper for UTF-16LE + Base64 encoding
2. Updated `encrypt()` to use encoded script
3. Updated `decrypt()` to use encoded script

This completely avoids quoting/escaping issues.

## Before/After

**Before:**
```powershell
powershell -Command "... FromBase64String(\"BASE64\") ..."
# -> Parser error on nested quotes
```

**After:**
```powershell
powershell -EncodedCommand <UTF16LE_BASE64_SCRIPT>
# -> No quoting issues, works reliably
```

## Additional Changes

- Added `error` action type to `SecretizeKeyResult` (distinct from `placeholder`)
- Added `errorCount` to `SecretizeResult`
- Added `storage_errors` to `AddResult`
- Updated `formatSecretizeOutput()` to show `✖ storage failed` for errors
- Added tests for `encodePowerShellScript()`

## Test plan

- [x] All 457 tests passing
- [x] Build succeeds
- [ ] Manual testing on Windows (DPAPI encrypt/decrypt round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)