### PR TITLE
Shell: expose secrets + add secret alias + export hint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -218,6 +218,11 @@ program.addCommand(createShellCommand(getConfigPath));
 // secrets (Phase 3.6: secret management)
 program.addCommand(createSecretsCommand(getConfigPath));
 
+// Alias: secret = secrets (common typo/singular form)
+const secretCmd = createSecretsCommand(getConfigPath);
+secretCmd.name('secret').description('Alias for secrets');
+program.addCommand(secretCmd);
+
 // ============================================================
 // Default action: pfscan → pfscan view
 // ============================================================
@@ -232,7 +237,7 @@ function hasSubcommand(): boolean {
   const knownCommands = new Set([
     'view', 'v', 'tree', 't', 'explore', 'e', 'status', 'st',
     'scan', 's', 'archive', 'a', 'config', 'c',
-    'connectors', 'connector', 'sessions', 'monitor', 'events', 'rpc', 'summary', 'permissions', 'record', 'doctor', 'shell', 'secrets', 'help'
+    'connectors', 'connector', 'sessions', 'monitor', 'events', 'rpc', 'summary', 'permissions', 'record', 'doctor', 'shell', 'secrets', 'secret', 'help'
   ]);
 
   for (let i = 2; i < process.argv.length; i++) {

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -333,10 +333,17 @@ export function createSecretsCommand(getConfigPath: () => string): Command {
   secrets
     .command('export')
     .description('Export secrets to encrypted bundle file')
-    .requiredOption('-o, --output <file>', 'Output file path')
+    .option('-o, --output <file>', 'Output file path (required)')
     .option('--format <format>', 'Output format (json)', 'json')
     .action(async (options) => {
       try {
+        // Validate required -o option with friendly hint
+        if (!options.output) {
+          outputError('Required: -o, --output <file>');
+          output('Example: pfscan secrets export -o proofscan-secrets.export.json');
+          process.exit(1);
+        }
+
         const configPath = getConfigPath();
         const configDir = dirname(configPath);
 

--- a/src/shell/repl.ts
+++ b/src/shell/repl.ts
@@ -10,6 +10,7 @@ import {
   TOP_LEVEL_COMMANDS,
   ROUTER_COMMANDS,
   BLOCKED_IN_SHELL,
+  BLOCKED_SUBCOMMANDS_IN_SHELL,
   DEFAULT_COMPLETION_LIMIT,
   SESSION_SEARCH_LIMIT,
   getAllowedCommands,
@@ -531,6 +532,15 @@ Tips:
     if (BLOCKED_IN_SHELL.includes(command)) {
       printError(`'${command}' is not available in shell mode (stdin conflict)`);
       printInfo('Exit shell first, then run: pfscan ' + command);
+      return;
+    }
+
+    // Block subcommands that use hidden input (stdin conflict)
+    const subcommand = tokens.length > 1 ? tokens[1] : '';
+    const fullCommand = `${command} ${subcommand}`;
+    if (BLOCKED_SUBCOMMANDS_IN_SHELL.includes(fullCommand)) {
+      printError(`'${fullCommand}' is not available in shell mode (requires hidden input)`);
+      printInfo('Exit shell first, then run: pfscan ' + tokens.join(' '));
       return;
     }
 

--- a/src/shell/types.ts
+++ b/src/shell/types.ts
@@ -57,6 +57,7 @@ export const TOP_LEVEL_COMMANDS = [
   'permissions',
   'record',
   'doctor',
+  'secrets', 'secret',
 ];
 
 /**
@@ -72,6 +73,8 @@ export const COMMAND_SUBCOMMANDS: Record<string, string[]> = {
   events: ['ls', 'export'],
   rpc: ['list', 'show'],
   record: ['dry-run'],
+  secrets: ['list', 'set', 'edit', 'prune', 'export', 'import'],
+  secret: ['list', 'set', 'edit', 'prune', 'export', 'import'],
 };
 
 /**
@@ -102,6 +105,14 @@ export const COMMAND_OPTIONS: Record<string, string[]> = {
   sessions: ['--limit'],
   archive: ['--older-than', '--dry-run'],
   record: ['--output'],
+  secrets: ['--orphans', '--clip', '--dry-run', '--older-than', '-o', '--output', '--overwrite'],
+  secret: ['--orphans', '--clip', '--dry-run', '--older-than', '-o', '--output', '--overwrite'],
+  'secrets list': ['--orphans'],
+  'secrets prune': ['--dry-run', '--older-than'],
+  'secrets export': ['-o', '--output'],
+  'secrets import': ['--overwrite'],
+  'secrets set': ['--clip'],
+  'secrets edit': ['--clip'],
 };
 
 /**
@@ -126,6 +137,25 @@ export const ROUTER_COMMANDS = ['cc', 'cd', 'ls', 'show', '..'];
  * Users should exit shell first, then run: pfscan <command>
  */
 export const BLOCKED_IN_SHELL = ['explore', 'e'];
+
+/**
+ * Subcommands blocked in shell mode due to stdin conflicts (hidden input).
+ *
+ * These subcommands use readline for password/secret input which conflicts
+ * with the shell's readline. Users should exit shell first.
+ *
+ * Format: "command subcommand" (e.g., "secrets set")
+ */
+export const BLOCKED_SUBCOMMANDS_IN_SHELL = [
+  'secrets set',
+  'secrets edit',
+  'secrets export',
+  'secrets import',
+  'secret set',
+  'secret edit',
+  'secret export',
+  'secret import',
+];
 
 /**
  * Default limit for completion results (sessions, etc.)


### PR DESCRIPTION
## Summary

- Enable `secrets` command in shell mode with TAB completion
- Add `secret` CLI alias (common typo/singular form)
- Improve `secrets export` error message when `-o` missing

## Before/After Behavior

### AC-1: secrets in shell

**Before:**
```
proofscan:/mcp > secrets
Unknown command: secrets
```

**After:**
```
proofscan:/mcp > secrets list
Found 2 secret(s):

  CONNECTOR          ENV_KEY                    STATUS    PROVIDER  CREATED
  ─────────────────  ─────────────────────────  ────────  ────────  ───────────────────
  mcp                API_KEY                    BOUND     keychain  2024-01-15T10:30:00

proofscan:/mcp > secrets set myconn API_KEY
'secrets set' is not available in shell mode (requires hidden input)
Exit shell first, then run: pfscan secrets set myconn API_KEY
```

TAB completion now works:
```
proofscan:/mcp > secrets <TAB>
list  set  edit  prune  export  import

proofscan:/mcp > secrets list --<TAB>
--orphans  --json
```

### AC-2: CLI alias

**Before:**
```
$ pfscan secret list
Unknown command: secret
```

**After:**
```
$ pfscan secret list
Found 2 secret(s):
...
```

### AC-3: export error message

**Before:**
```
$ pfscan secrets export
error: required option '-o, --output <file>' not specified
```

**After:**
```
$ pfscan secrets export
ERROR: Required: -o, --output <file>
Example: pfscan secrets export -o proofscan-secrets.export.json
```

## Commands to Verify

```bash
# Build
npm run build

# Run tests
npm test

# Shell mode verification
pfscan shell
> secrets list
> secrets set myconn KEY    # Should show blocked message
> exit

# CLI alias
pfscan secret list

# Export hint
pfscan secrets export
```

## Test Results

```
✓ src/shell/shell.test.ts  (49 tests) 15ms

Test Files  1 passed (1)
     Tests  49 passed (49)
```

17 new tests added for secrets in shell:
- TOP_LEVEL_COMMANDS includes secrets/secret
- COMMAND_SUBCOMMANDS has correct subcommands
- BLOCKED_SUBCOMMANDS_IN_SHELL blocks stdin-conflicting commands
- TAB completion works for secrets command and subcommands

## Files Changed

- `src/shell/types.ts` - Add secrets to command registries
- `src/shell/repl.ts` - Add subcommand blocking logic
- `src/cli.ts` - Add secret alias
- `src/commands/secrets.ts` - Improve export error message
- `src/shell/shell.test.ts` - Add 17 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)