### PR TITLE
UX: secrets export prompt + shell guidance

### DIFF
--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -347,7 +347,7 @@ export function createSecretsCommand(getConfigPath: () => string): Command {
         const configPath = getConfigPath();
         const configDir = dirname(configPath);
 
-        output('Enter passphrase to encrypt the export:');
+        output('Enter passphrase to encrypt the export (min 12 chars):');
         const passphrase = await readSecretHidden();
 
         if (!passphrase || passphrase.length < 12) {

--- a/src/shell/repl.ts
+++ b/src/shell/repl.ts
@@ -540,7 +540,13 @@ Tips:
     const fullCommand = `${command} ${subcommand}`;
     if (BLOCKED_SUBCOMMANDS_IN_SHELL.includes(fullCommand)) {
       printError(`'${fullCommand}' is not available in shell mode (requires hidden input)`);
-      printInfo('Exit shell first, then run: pfscan ' + tokens.join(' '));
+      // Provide copy-paste ready command with default output file for export
+      if (fullCommand === 'secrets export' || fullCommand === 'secret export') {
+        printInfo('Exit shell first, then run:');
+        printInfo('  pfscan secrets export -o proofscan-secrets.export.json');
+      } else {
+        printInfo('Exit shell first, then run: pfscan ' + tokens.join(' '));
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

- Show passphrase minimum length requirement upfront in export prompt
- Improve shell mode guidance for `secrets export` with copy-paste command

## Before/After Behavior

### A) Passphrase Prompt

**Before:**
```
$ pfscan secrets export -o backup.json
Enter passphrase to encrypt the export:
********
ERROR: Passphrase must be at least 12 characters
```

**After:**
```
$ pfscan secrets export -o backup.json
Enter passphrase to encrypt the export (min 12 chars):
```

User now knows the requirement upfront, avoiding failed attempts.

### B) Shell Mode Guidance

**Before:**
```
proofscan:/mcp > secrets export
ERROR: 'secrets export' is not available in shell mode (requires hidden input)
ℹ Exit shell first, then run: pfscan secrets export
```
(Missing -o option in the hint)

**After:**
```
proofscan:/mcp > secrets export
ERROR: 'secrets export' is not available in shell mode (requires hidden input)
ℹ Exit shell first, then run:
ℹ   pfscan secrets export -o proofscan-secrets.export.json
```

User gets a complete, copy-paste ready command.

## Commands to Verify

```bash
# Build
npm run build

# Run tests
npm test

# Verify passphrase prompt (requires secrets to export)
pfscan secrets export -o test.json

# Verify shell guidance
pfscan shell
> secrets export
> exit
```

## Test Results

```
 Test Files  23 passed (23)
      Tests  495 passed (495)
```

## Files Changed

- `src/commands/secrets.ts` - Add "(min 12 chars)" to prompt
- `src/shell/repl.ts` - Improve export guidance with copy-paste command

🤖 Generated with [Claude Code](https://claude.com/claude-code)