### PR TITLE
feat(popl): improve ls/show UX (oneline, view arg, observed time)

### DIFF
--- a/src/commands/popl.ts
+++ b/src/commands/popl.ts
@@ -98,7 +98,6 @@ async function resolveEntryId(
   cwd: string,
   idOrPrefix: string
 ): Promise<{ success: true; entryId: string; entryPath: string } | { success: false; error: string; candidates?: string[] }> {
-  const entriesDir = getPoplEntriesDir(cwd);
   const entries = await listPoplEntries(cwd);
 
   // Exact match first


### PR DESCRIPTION
## Summary

- Add `--oneline` option to `pfscan popl ls`
- Add `[view]` positional argument to `pfscan popl show <id> [view]`
- Implement prefix matching for entry IDs
- Remove absolute paths from default output (public ledger safety)
- Change time labels to Observed/Recorded

## Changes

### `pfscan popl ls --oneline`
One line per entry with Observed time in local timezone:
```
2026-01-04 20:35:00 +09:00 | Test Entry Title | 01JGTEST123456789ABCDEF
```

### `pfscan popl show <id> [view]`
View artifacts directly:
- `pfscan popl show <id> status` - View status.json
- `pfscan popl show <id> rpc` - View rpc.sanitized.jsonl
- `pfscan popl show <id> log` - View validation-run.log
- `pfscan popl show <id> popl` - View POPL.yml

### Prefix Resolution
Short prefixes work if unique:
```bash
pfscan popl show 01JG status  # Works if only one entry starts with 01JG
```

### Path Safety
- Default output uses relative paths
- `--local` flag shows absolute paths (for debugging)

## Breaking Changes

None.

## Manual Testing

```bash
pfscan popl ls --oneline
pfscan popl show <id>
pfscan popl show <id> status
pfscan popl show <prefix> rpc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)