### PR TITLE
feat(html): add analytics panel to connector HTML export

### DIFF
--- a/src/commands/connectors.ts
+++ b/src/commands/connectors.ts
@@ -26,6 +26,7 @@ import {
   validateEmbedMaxBytes,
   ensureOutputDir,
   safeWriteFile,
+  computeConnectorAnalytics,
 } from '../html/index.js';
 import type {
   HtmlConnectorReportV1,
@@ -360,7 +361,14 @@ async function exportConnectorHtml(
     console.log(t('html.redactedNote'));
   }
 
-  // 5. Build connector report
+  // 5. Compute analytics from session reports
+  const analytics = computeConnectorAnalytics({
+    sessionReports,
+    sessionsTotal: totalSessionCount,
+    sessionsDisplayed: displayedSessions.length,
+  });
+
+  // 6. Build connector report
   const report: HtmlConnectorReportV1 = {
     meta: {
       schemaVersion: 1,
@@ -388,9 +396,10 @@ async function exportConnectorHtml(
       total_latency_ms: sessionReports[s.session_id]?.session.total_latency_ms ?? null,
     })),
     session_reports: sessionReports,
+    analytics,
   };
 
-  // 6. Generate and write HTML
+  // 7. Generate and write HTML
   const html = generateConnectorHtml(report);
   const filename = getConnectorHtmlFilename(connectorId);
   const outputPath = path.join(validatedOutDir, filename);

--- a/src/html/analytics.test.ts
+++ b/src/html/analytics.test.ts
@@ -1,0 +1,681 @@
+/**
+ * Tests for analytics computation (Phase 5.2)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeConnectorAnalytics,
+  LATENCY_BUCKETS,
+  P95_MIN_SAMPLES,
+} from './analytics.js';
+import type {
+  HtmlSessionReportV1,
+  SessionRpcDetail,
+  PayloadData,
+} from './types.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createPayload(size: number = 100): PayloadData {
+  return {
+    json: { test: 'data' },
+    size,
+    truncated: false,
+    preview: null,
+  };
+}
+
+function createRpc(overrides: Partial<SessionRpcDetail> = {}): SessionRpcDetail {
+  return {
+    rpc_id: 'rpc-001',
+    method: 'test/method',
+    status: 'OK',
+    latency_ms: 50,
+    request_ts: '2024-01-15T10:00:00.000Z',
+    response_ts: '2024-01-15T10:00:00.050Z',
+    error_code: null,
+    request: createPayload(),
+    response: createPayload(),
+    ...overrides,
+  };
+}
+
+function createSessionReport(rpcs: SessionRpcDetail[]): HtmlSessionReportV1 {
+  return {
+    meta: {
+      schemaVersion: 1,
+      generatedAt: '2024-01-15T12:00:00.000Z',
+      generatedBy: 'proofscan v0.1.0',
+      redacted: false,
+    },
+    session: {
+      session_id: 'session-001',
+      connector_id: 'test-connector',
+      started_at: '2024-01-15T10:00:00.000Z',
+      ended_at: '2024-01-15T11:00:00.000Z',
+      exit_reason: null,
+      rpc_count: rpcs.length,
+      event_count: rpcs.length * 2,
+      total_latency_ms: rpcs.reduce((sum, r) => sum + (r.latency_ms ?? 0), 0),
+    },
+    rpcs,
+  };
+}
+
+// ============================================================================
+// KPI Tests
+// ============================================================================
+
+describe('computeConnectorAnalytics - KPIs', () => {
+  it('counts status correctly (OK/ERR/PENDING)', () => {
+    const rpcs = [
+      createRpc({ status: 'OK' }),
+      createRpc({ status: 'OK' }),
+      createRpc({ status: 'ERR' }),
+      createRpc({ status: 'PENDING' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.kpis.rpc_total).toBe(4);
+    expect(result.kpis.rpc_ok).toBe(2);
+    expect(result.kpis.rpc_err).toBe(1);
+    expect(result.kpis.rpc_pending).toBe(1);
+  });
+
+  it('calculates average latency correctly', () => {
+    const rpcs = [
+      createRpc({ latency_ms: 10 }),
+      createRpc({ latency_ms: 20 }),
+      createRpc({ latency_ms: 30 }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.kpis.avg_latency_ms).toBe(20); // (10+20+30)/3 = 20
+  });
+
+  it('returns null for avg_latency_ms when no RPCs have latency', () => {
+    const rpcs = [
+      createRpc({ latency_ms: null }),
+      createRpc({ latency_ms: null }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.kpis.avg_latency_ms).toBeNull();
+  });
+
+  it('calculates P95 latency with nearest-rank method when n >= 20', () => {
+    // Create 20 RPCs with latencies 1-20
+    const rpcs = Array.from({ length: 20 }, (_, i) =>
+      createRpc({ latency_ms: i + 1, rpc_id: `rpc-${i}` })
+    );
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    // P95 with nearest-rank: k = ceil(0.95 * 20) = 19, sorted[18] = 19
+    expect(result.kpis.p95_latency_ms).toBe(19);
+  });
+
+  it('returns null for P95 when n < 20', () => {
+    const rpcs = Array.from({ length: 19 }, (_, i) =>
+      createRpc({ latency_ms: i + 1, rpc_id: `rpc-${i}` })
+    );
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.kpis.p95_latency_ms).toBeNull();
+  });
+
+  it('calculates max latency correctly', () => {
+    const rpcs = [
+      createRpc({ latency_ms: 10 }),
+      createRpc({ latency_ms: 100 }),
+      createRpc({ latency_ms: 50 }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.kpis.max_latency_ms).toBe(100);
+  });
+
+  it('sums request and response bytes correctly', () => {
+    const rpcs = [
+      createRpc({
+        request: createPayload(100),
+        response: createPayload(200),
+      }),
+      createRpc({
+        request: createPayload(150),
+        response: createPayload(250),
+      }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.kpis.total_request_bytes).toBe(250); // 100 + 150
+    expect(result.kpis.total_response_bytes).toBe(450); // 200 + 250
+  });
+
+  it('extracts top tool from top_tools', () => {
+    const rpcs = [
+      createRpc({ method: 'tools/call', request: { json: { params: { name: 'read_file' } }, size: 100, truncated: false, preview: null } }),
+      createRpc({ method: 'tools/call', request: { json: { params: { name: 'read_file' } }, size: 100, truncated: false, preview: null } }),
+      createRpc({ method: 'tools/call', request: { json: { params: { name: 'write_file' } }, size: 100, truncated: false, preview: null } }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.kpis.top_tool_name).toBe('read_file');
+    expect(result.kpis.top_tool_calls).toBe(2);
+  });
+});
+
+// ============================================================================
+// Heatmap Tests
+// ============================================================================
+
+describe('computeConnectorAnalytics - Heatmap', () => {
+  it('groups RPCs by UTC date', () => {
+    const rpcs = [
+      createRpc({ request_ts: '2024-01-15T10:00:00.000Z' }),
+      createRpc({ request_ts: '2024-01-15T23:00:00.000Z' }),
+      createRpc({ request_ts: '2024-01-16T05:00:00.000Z' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.heatmap.start_date).toBe('2024-01-15');
+    expect(result.heatmap.end_date).toBe('2024-01-16');
+    expect(result.heatmap.cells.length).toBe(2); // 2 days
+    expect(result.heatmap.cells[0]).toEqual({ date: '2024-01-15', count: 2 });
+    expect(result.heatmap.cells[1]).toEqual({ date: '2024-01-16', count: 1 });
+  });
+
+  it('fills gaps with count=0 days', () => {
+    const rpcs = [
+      createRpc({ request_ts: '2024-01-15T10:00:00.000Z' }),
+      createRpc({ request_ts: '2024-01-18T10:00:00.000Z' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.heatmap.cells.length).toBe(4); // 15, 16, 17, 18
+    expect(result.heatmap.cells[0]).toEqual({ date: '2024-01-15', count: 1 });
+    expect(result.heatmap.cells[1]).toEqual({ date: '2024-01-16', count: 0 });
+    expect(result.heatmap.cells[2]).toEqual({ date: '2024-01-17', count: 0 });
+    expect(result.heatmap.cells[3]).toEqual({ date: '2024-01-18', count: 1 });
+  });
+
+  it('calculates max_count correctly', () => {
+    const rpcs = [
+      createRpc({ request_ts: '2024-01-15T10:00:00.000Z' }),
+      createRpc({ request_ts: '2024-01-15T11:00:00.000Z' }),
+      createRpc({ request_ts: '2024-01-15T12:00:00.000Z' }),
+      createRpc({ request_ts: '2024-01-16T10:00:00.000Z' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.heatmap.max_count).toBe(3);
+  });
+
+  it('handles empty RPCs gracefully', () => {
+    const sessionReports = { 'session-001': createSessionReport([]) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.heatmap.cells.length).toBe(1);
+    expect(result.heatmap.cells[0].count).toBe(0);
+    expect(result.heatmap.max_count).toBe(0);
+  });
+});
+
+// ============================================================================
+// Latency Histogram Tests
+// ============================================================================
+
+describe('computeConnectorAnalytics - Latency Histogram', () => {
+  it('has correct fixed bucket definitions', () => {
+    expect(LATENCY_BUCKETS).toHaveLength(8);
+    expect(LATENCY_BUCKETS[0]).toEqual({ label: '0-10', from_ms: 0, to_ms: 10 });
+    expect(LATENCY_BUCKETS[7]).toEqual({ label: '1000+', from_ms: 1000, to_ms: null });
+  });
+
+  it('places latencies in correct buckets (boundary conditions)', () => {
+    const rpcs = [
+      createRpc({ latency_ms: 0, rpc_id: 'rpc-0' }),    // 0-10 bucket
+      createRpc({ latency_ms: 9, rpc_id: 'rpc-9' }),    // 0-10 bucket
+      createRpc({ latency_ms: 10, rpc_id: 'rpc-10' }),  // 10-25 bucket (from_ms <= x < to_ms)
+      createRpc({ latency_ms: 24, rpc_id: 'rpc-24' }),  // 10-25 bucket
+      createRpc({ latency_ms: 25, rpc_id: 'rpc-25' }),  // 25-50 bucket
+      createRpc({ latency_ms: 1000, rpc_id: 'rpc-1000' }), // 1000+ bucket
+      createRpc({ latency_ms: 5000, rpc_id: 'rpc-5000' }), // 1000+ bucket
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    const buckets = result.latency.buckets;
+    expect(buckets[0].count).toBe(2);  // 0-10: 0, 9
+    expect(buckets[1].count).toBe(2);  // 10-25: 10, 24
+    expect(buckets[2].count).toBe(1);  // 25-50: 25
+    expect(buckets[7].count).toBe(2);  // 1000+: 1000, 5000
+  });
+
+  it('tracks sample_size and excluded_count correctly', () => {
+    const rpcs = [
+      createRpc({ latency_ms: 50 }),
+      createRpc({ latency_ms: 100 }),
+      createRpc({ latency_ms: null }),
+      createRpc({ latency_ms: null }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.latency.sample_size).toBe(2);
+    expect(result.latency.excluded_count).toBe(2);
+  });
+});
+
+// ============================================================================
+// Top Tools Tests
+// ============================================================================
+
+describe('computeConnectorAnalytics - Top Tools', () => {
+  it('only counts tools/call RPCs', () => {
+    const rpcs = [
+      createRpc({ method: 'tools/call', request: { json: { params: { name: 'read_file' } }, size: 100, truncated: false, preview: null } }),
+      createRpc({ method: 'tools/list', request: createPayload() }),
+      createRpc({ method: 'initialize', request: createPayload() }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.top_tools.total_calls).toBe(1);
+    expect(result.top_tools.items).toHaveLength(1);
+  });
+
+  it('extracts tool name from params.name', () => {
+    const rpcs = [
+      createRpc({ method: 'tools/call', request: { json: { params: { name: 'my_tool' } }, size: 100, truncated: false, preview: null } }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.top_tools.items[0].name).toBe('my_tool');
+  });
+
+  it('falls back to params.tool when params.name is missing', () => {
+    const rpcs = [
+      createRpc({ method: 'tools/call', request: { json: { params: { tool: 'fallback_tool' } }, size: 100, truncated: false, preview: null } }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.top_tools.items[0].name).toBe('fallback_tool');
+  });
+
+  it('falls back to params.toolName when params.name and params.tool are missing', () => {
+    const rpcs = [
+      createRpc({ method: 'tools/call', request: { json: { params: { toolName: 'alt_tool' } }, size: 100, truncated: false, preview: null } }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.top_tools.items[0].name).toBe('alt_tool');
+  });
+
+  it('sorts by count descending and takes top 5', () => {
+    const rpcs = [
+      // Tool A: 5 calls
+      ...Array.from({ length: 5 }, (_, i) =>
+        createRpc({ method: 'tools/call', rpc_id: `a-${i}`, request: { json: { params: { name: 'tool_a' } }, size: 100, truncated: false, preview: null } })
+      ),
+      // Tool B: 4 calls
+      ...Array.from({ length: 4 }, (_, i) =>
+        createRpc({ method: 'tools/call', rpc_id: `b-${i}`, request: { json: { params: { name: 'tool_b' } }, size: 100, truncated: false, preview: null } })
+      ),
+      // Tool C: 3 calls
+      ...Array.from({ length: 3 }, (_, i) =>
+        createRpc({ method: 'tools/call', rpc_id: `c-${i}`, request: { json: { params: { name: 'tool_c' } }, size: 100, truncated: false, preview: null } })
+      ),
+      // Tool D: 2 calls
+      ...Array.from({ length: 2 }, (_, i) =>
+        createRpc({ method: 'tools/call', rpc_id: `d-${i}`, request: { json: { params: { name: 'tool_d' } }, size: 100, truncated: false, preview: null } })
+      ),
+      // Tool E: 1 call
+      createRpc({ method: 'tools/call', rpc_id: 'e-0', request: { json: { params: { name: 'tool_e' } }, size: 100, truncated: false, preview: null } }),
+      // Tool F: 1 call (should be excluded from top 5 as 6th)
+      createRpc({ method: 'tools/call', rpc_id: 'f-0', request: { json: { params: { name: 'tool_f' } }, size: 100, truncated: false, preview: null } }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.top_tools.items).toHaveLength(5);
+    expect(result.top_tools.items[0].name).toBe('tool_a');
+    expect(result.top_tools.items[0].count).toBe(5);
+    expect(result.top_tools.items[4].name).toBe('tool_e');
+  });
+
+  it('calculates percentage correctly', () => {
+    const rpcs = [
+      ...Array.from({ length: 3 }, (_, i) =>
+        createRpc({ method: 'tools/call', rpc_id: `a-${i}`, request: { json: { params: { name: 'tool_a' } }, size: 100, truncated: false, preview: null } })
+      ),
+      createRpc({ method: 'tools/call', rpc_id: 'b-0', request: { json: { params: { name: 'tool_b' } }, size: 100, truncated: false, preview: null } }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.top_tools.total_calls).toBe(4);
+    expect(result.top_tools.items[0].pct).toBe(75); // 3/4 = 75%
+    expect(result.top_tools.items[1].pct).toBe(25); // 1/4 = 25%
+  });
+
+  it('returns empty items when no tools/call RPCs exist', () => {
+    const rpcs = [
+      createRpc({ method: 'tools/list' }),
+      createRpc({ method: 'initialize' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.top_tools.items).toHaveLength(0);
+    expect(result.top_tools.total_calls).toBe(0);
+  });
+});
+
+// ============================================================================
+// Method Distribution Tests
+// ============================================================================
+
+describe('computeConnectorAnalytics - Method Distribution', () => {
+  it('counts RPCs by method', () => {
+    const rpcs = [
+      createRpc({ method: 'tools/call', rpc_id: 'rpc-1' }),
+      createRpc({ method: 'tools/call', rpc_id: 'rpc-2' }),
+      createRpc({ method: 'tools/list', rpc_id: 'rpc-3' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.method_distribution.total_rpcs).toBe(3);
+    expect(result.method_distribution.slices).toHaveLength(2);
+    expect(result.method_distribution.slices[0]).toEqual({
+      method: 'tools/call',
+      count: 2,
+      pct: 67, // 2/3 = 66.67% rounded to 67%
+    });
+    expect(result.method_distribution.slices[1]).toEqual({
+      method: 'tools/list',
+      count: 1,
+      pct: 33, // 1/3 = 33.33% rounded to 33%
+    });
+  });
+
+  it('sorts by count descending and takes top 5 + Others', () => {
+    const rpcs = [
+      // Method A: 10 calls
+      ...Array.from({ length: 10 }, (_, i) =>
+        createRpc({ method: 'method_a', rpc_id: `a-${i}` })
+      ),
+      // Method B: 8 calls
+      ...Array.from({ length: 8 }, (_, i) =>
+        createRpc({ method: 'method_b', rpc_id: `b-${i}` })
+      ),
+      // Method C: 6 calls
+      ...Array.from({ length: 6 }, (_, i) =>
+        createRpc({ method: 'method_c', rpc_id: `c-${i}` })
+      ),
+      // Method D: 4 calls
+      ...Array.from({ length: 4 }, (_, i) =>
+        createRpc({ method: 'method_d', rpc_id: `d-${i}` })
+      ),
+      // Method E: 2 calls
+      ...Array.from({ length: 2 }, (_, i) =>
+        createRpc({ method: 'method_e', rpc_id: `e-${i}` })
+      ),
+      // Method F: 1 call (should go to "Others")
+      createRpc({ method: 'method_f', rpc_id: 'f-0' }),
+      // Method G: 1 call (should go to "Others")
+      createRpc({ method: 'method_g', rpc_id: 'g-0' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    // Total: 32 RPCs
+    expect(result.method_distribution.total_rpcs).toBe(32);
+    expect(result.method_distribution.slices).toHaveLength(6); // Top 5 + Others
+
+    // Verify top 5 order
+    expect(result.method_distribution.slices[0].method).toBe('method_a');
+    expect(result.method_distribution.slices[0].count).toBe(10);
+    expect(result.method_distribution.slices[4].method).toBe('method_e');
+    expect(result.method_distribution.slices[4].count).toBe(2);
+
+    // Verify "Others" bucket
+    expect(result.method_distribution.slices[5].method).toBe('Others');
+    expect(result.method_distribution.slices[5].count).toBe(2); // F + G
+  });
+
+  it('does not include Others when 5 or fewer methods', () => {
+    const rpcs = [
+      createRpc({ method: 'method_a', rpc_id: 'rpc-1' }),
+      createRpc({ method: 'method_b', rpc_id: 'rpc-2' }),
+      createRpc({ method: 'method_c', rpc_id: 'rpc-3' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.method_distribution.slices).toHaveLength(3);
+    expect(result.method_distribution.slices.some((s) => s.method === 'Others')).toBe(false);
+  });
+
+  it('returns empty slices for no RPCs', () => {
+    const sessionReports = { 'session-001': createSessionReport([]) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.method_distribution.slices).toHaveLength(0);
+    expect(result.method_distribution.total_rpcs).toBe(0);
+  });
+
+  it('calculates percentages correctly', () => {
+    const rpcs = [
+      createRpc({ method: 'method_a', rpc_id: 'rpc-1' }),
+      createRpc({ method: 'method_a', rpc_id: 'rpc-2' }),
+      createRpc({ method: 'method_a', rpc_id: 'rpc-3' }),
+      createRpc({ method: 'method_b', rpc_id: 'rpc-4' }),
+    ];
+    const sessionReports = { 'session-001': createSessionReport(rpcs) };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 1,
+      sessionsDisplayed: 1,
+    });
+
+    expect(result.method_distribution.slices[0].pct).toBe(75); // 3/4 = 75%
+    expect(result.method_distribution.slices[1].pct).toBe(25); // 1/4 = 25%
+  });
+});
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+describe('computeConnectorAnalytics - Integration', () => {
+  it('handles multiple sessions correctly', () => {
+    const rpcs1 = [
+      createRpc({ status: 'OK', latency_ms: 10, rpc_id: 'rpc-1-1' }),
+      createRpc({ status: 'OK', latency_ms: 20, rpc_id: 'rpc-1-2' }),
+    ];
+    const rpcs2 = [
+      createRpc({ status: 'ERR', latency_ms: 30, rpc_id: 'rpc-2-1' }),
+    ];
+
+    const sessionReports = {
+      'session-001': createSessionReport(rpcs1),
+      'session-002': {
+        ...createSessionReport(rpcs2),
+        session: { ...createSessionReport(rpcs2).session, session_id: 'session-002' },
+      },
+    };
+
+    const result = computeConnectorAnalytics({
+      sessionReports,
+      sessionsTotal: 2,
+      sessionsDisplayed: 2,
+    });
+
+    expect(result.kpis.rpc_total).toBe(3);
+    expect(result.kpis.rpc_ok).toBe(2);
+    expect(result.kpis.rpc_err).toBe(1);
+    expect(result.kpis.avg_latency_ms).toBe(20); // (10+20+30)/3 = 20
+    expect(result.kpis.sessions_total).toBe(2);
+    expect(result.kpis.sessions_displayed).toBe(2);
+  });
+
+  it('handles empty session reports', () => {
+    const result = computeConnectorAnalytics({
+      sessionReports: {},
+      sessionsTotal: 0,
+      sessionsDisplayed: 0,
+    });
+
+    expect(result.kpis.rpc_total).toBe(0);
+    expect(result.kpis.avg_latency_ms).toBeNull();
+    expect(result.kpis.p95_latency_ms).toBeNull();
+    expect(result.kpis.max_latency_ms).toBeNull();
+    expect(result.heatmap.max_count).toBe(0);
+    expect(result.latency.sample_size).toBe(0);
+    expect(result.top_tools.items).toHaveLength(0);
+    expect(result.method_distribution.slices).toHaveLength(0);
+  });
+});

--- a/src/html/analytics.ts
+++ b/src/html/analytics.ts
@@ -1,0 +1,418 @@
+/**
+ * Analytics computation for Connector HTML reports (Phase 5.2)
+ *
+ * Computes KPIs, heatmap, latency histogram, and top tools
+ * from session report data.
+ */
+
+import type {
+  HtmlSessionReportV1,
+  SessionRpcDetail,
+  HtmlConnectorAnalyticsV1,
+  HtmlConnectorKpis,
+  HtmlHeatmapData,
+  HtmlHeatmapCell,
+  HtmlLatencyHistogram,
+  HtmlLatencyBucket,
+  HtmlTopToolsData,
+  HtmlTopTool,
+  HtmlMethodDistribution,
+  HtmlMethodSlice,
+} from './types.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Minimum sample size for P95 calculation.
+ * Below this threshold, P95 returns null to avoid statistical noise.
+ */
+export const P95_MIN_SAMPLES = 20;
+
+/**
+ * Fixed latency histogram buckets.
+ * to_ms: null means +infinity (for "1000+" bucket)
+ */
+export const LATENCY_BUCKETS = [
+  { label: '0-10', from_ms: 0, to_ms: 10 },
+  { label: '10-25', from_ms: 10, to_ms: 25 },
+  { label: '25-50', from_ms: 25, to_ms: 50 },
+  { label: '50-100', from_ms: 50, to_ms: 100 },
+  { label: '100-250', from_ms: 100, to_ms: 250 },
+  { label: '250-500', from_ms: 250, to_ms: 500 },
+  { label: '500-1000', from_ms: 500, to_ms: 1000 },
+  { label: '1000+', from_ms: 1000, to_ms: null }, // null = +infinity
+] as const;
+
+// ============================================================================
+// Main Entry Point
+// ============================================================================
+
+/**
+ * Compute all analytics for a connector report.
+ */
+export function computeConnectorAnalytics(args: {
+  sessionReports: Record<string, HtmlSessionReportV1>;
+  sessionsTotal: number;
+  sessionsDisplayed: number;
+}): HtmlConnectorAnalyticsV1 {
+  const { sessionReports, sessionsTotal, sessionsDisplayed } = args;
+
+  // Collect all RPCs from all sessions
+  const allRpcs: SessionRpcDetail[] = [];
+  for (const report of Object.values(sessionReports)) {
+    allRpcs.push(...report.rpcs);
+  }
+
+  // Compute each analytics component
+  const topTools = computeTopTools(allRpcs);
+  const kpis = computeKpis(allRpcs, sessionsTotal, sessionsDisplayed, topTools);
+  const heatmap = computeHeatmap(allRpcs);
+  const latency = computeLatencyHistogram(allRpcs);
+  const methodDistribution = computeMethodDistribution(allRpcs);
+
+  return {
+    kpis,
+    heatmap,
+    latency,
+    top_tools: topTools,
+    method_distribution: methodDistribution,
+  };
+}
+
+// ============================================================================
+// KPI Computation
+// ============================================================================
+
+/**
+ * Compute KPI metrics from RPCs.
+ */
+function computeKpis(
+  rpcs: SessionRpcDetail[],
+  sessionsTotal: number,
+  sessionsDisplayed: number,
+  topTools: HtmlTopToolsData
+): HtmlConnectorKpis {
+  // Count by status
+  let okCount = 0;
+  let errCount = 0;
+  let pendingCount = 0;
+
+  // Latency collection
+  const latencies: number[] = [];
+
+  // Bytes
+  let totalRequestBytes = 0;
+  let totalResponseBytes = 0;
+
+  for (const rpc of rpcs) {
+    // Status counting
+    switch (rpc.status) {
+      case 'OK':
+        okCount++;
+        break;
+      case 'ERR':
+        errCount++;
+        break;
+      case 'PENDING':
+        pendingCount++;
+        break;
+    }
+
+    // Latency
+    if (rpc.latency_ms !== null) {
+      latencies.push(rpc.latency_ms);
+    }
+
+    // Bytes
+    totalRequestBytes += rpc.request.size;
+    totalResponseBytes += rpc.response.size;
+  }
+
+  // Latency statistics
+  const avgLatency = latencies.length > 0 ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : null;
+  const p95Latency = computeP95(latencies);
+  const maxLatency = latencies.length > 0 ? Math.max(...latencies) : null;
+
+  // Top tool from topTools
+  const topToolName = topTools.items.length > 0 ? topTools.items[0].name : null;
+  const topToolCalls = topTools.items.length > 0 ? topTools.items[0].count : null;
+
+  return {
+    rpc_total: rpcs.length,
+    rpc_ok: okCount,
+    rpc_err: errCount,
+    rpc_pending: pendingCount,
+    avg_latency_ms: avgLatency,
+    p95_latency_ms: p95Latency,
+    max_latency_ms: maxLatency,
+    total_request_bytes: totalRequestBytes,
+    total_response_bytes: totalResponseBytes,
+    sessions_total: sessionsTotal,
+    sessions_displayed: sessionsDisplayed,
+    top_tool_name: topToolName,
+    top_tool_calls: topToolCalls,
+  };
+}
+
+/**
+ * Compute P95 latency using nearest-rank method.
+ * Returns null if sample size < P95_MIN_SAMPLES.
+ *
+ * Algorithm: k = ceil(0.95 * n), take sorted[k-1]
+ */
+function computeP95(latencies: number[]): number | null {
+  const n = latencies.length;
+  if (n < P95_MIN_SAMPLES) {
+    return null;
+  }
+
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const k = Math.ceil(0.95 * n);
+  return sorted[k - 1];
+}
+
+// ============================================================================
+// Heatmap Computation
+// ============================================================================
+
+/**
+ * Compute activity heatmap from RPCs.
+ * Groups RPCs by UTC date and fills gaps with zero-count days.
+ *
+ * Note: request_ts is stored in UTC ISO8601 format (Z suffix),
+ * so slice(0, 10) gives the UTC date.
+ */
+function computeHeatmap(rpcs: SessionRpcDetail[]): HtmlHeatmapData {
+  if (rpcs.length === 0) {
+    const today = new Date().toISOString().slice(0, 10);
+    return {
+      start_date: today,
+      end_date: today,
+      cells: [{ date: today, count: 0 }],
+      max_count: 0,
+    };
+  }
+
+  // Count RPCs per UTC date
+  const dateCounts = new Map<string, number>();
+  for (const rpc of rpcs) {
+    // request_ts is stored in UTC ISO8601 (Z suffix), so slice(0, 10) gives UTC date
+    const date = rpc.request_ts.slice(0, 10);
+    dateCounts.set(date, (dateCounts.get(date) || 0) + 1);
+  }
+
+  // Find date range
+  const dates = Array.from(dateCounts.keys()).sort();
+  const startDate = dates[0];
+  const endDate = dates[dates.length - 1];
+
+  // Fill gaps with zero-count days
+  const cells: HtmlHeatmapCell[] = [];
+  const current = new Date(startDate + 'T00:00:00Z');
+  const end = new Date(endDate + 'T00:00:00Z');
+
+  while (current <= end) {
+    const dateStr = current.toISOString().slice(0, 10);
+    cells.push({
+      date: dateStr,
+      count: dateCounts.get(dateStr) || 0,
+    });
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+
+  // Calculate max count for intensity scaling
+  const maxCount = Math.max(...cells.map((c) => c.count));
+
+  return {
+    start_date: startDate,
+    end_date: endDate,
+    cells,
+    max_count: maxCount,
+  };
+}
+
+// ============================================================================
+// Latency Histogram Computation
+// ============================================================================
+
+/**
+ * Compute latency histogram using fixed buckets.
+ */
+function computeLatencyHistogram(rpcs: SessionRpcDetail[]): HtmlLatencyHistogram {
+  // Initialize buckets with zero counts
+  const buckets: HtmlLatencyBucket[] = LATENCY_BUCKETS.map((b) => ({
+    label: b.label,
+    from_ms: b.from_ms,
+    to_ms: b.to_ms,
+    count: 0,
+  }));
+
+  let sampleSize = 0;
+  let excludedCount = 0;
+
+  for (const rpc of rpcs) {
+    if (rpc.latency_ms === null) {
+      excludedCount++;
+      continue;
+    }
+
+    sampleSize++;
+    const latency = rpc.latency_ms;
+
+    // Find matching bucket
+    // Bucket condition: from_ms <= latency < to_ms (or to_ms is null for +infinity)
+    for (const bucket of buckets) {
+      const inLowerBound = latency >= bucket.from_ms;
+      const inUpperBound = bucket.to_ms === null || latency < bucket.to_ms;
+      if (inLowerBound && inUpperBound) {
+        bucket.count++;
+        break;
+      }
+    }
+  }
+
+  return {
+    buckets,
+    sample_size: sampleSize,
+    excluded_count: excludedCount,
+  };
+}
+
+// ============================================================================
+// Top Tools Computation
+// ============================================================================
+
+/**
+ * Compute top 5 tools from tools/call RPCs.
+ *
+ * Tool name extraction fallback chain: params.name ?? params.tool ?? params.toolName
+ * If none found, the RPC is skipped (not counted as "unknown").
+ */
+function computeTopTools(rpcs: SessionRpcDetail[]): HtmlTopToolsData {
+  const toolCounts = new Map<string, number>();
+  let totalCalls = 0;
+
+  for (const rpc of rpcs) {
+    if (rpc.method !== 'tools/call') {
+      continue;
+    }
+
+    // Extract tool name from request payload
+    const toolName = extractToolName(rpc.request.json);
+    if (toolName === null) {
+      continue; // Skip if no tool name found
+    }
+
+    toolCounts.set(toolName, (toolCounts.get(toolName) || 0) + 1);
+    totalCalls++;
+  }
+
+  // Sort by count descending and take top 5
+  const sorted = Array.from(toolCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+
+  const items: HtmlTopTool[] = sorted.map(([name, count]) => ({
+    name,
+    count,
+    pct: totalCalls > 0 ? Math.round((count / totalCalls) * 100) : 0,
+  }));
+
+  return {
+    items,
+    total_calls: totalCalls,
+  };
+}
+
+/**
+ * Extract tool name from request JSON.
+ * Fallback chain: params.name ?? params.tool ?? params.toolName
+ */
+function extractToolName(json: unknown): string | null {
+  if (json === null || typeof json !== 'object') {
+    return null;
+  }
+
+  const obj = json as Record<string, unknown>;
+  const params = obj.params;
+
+  if (params === null || typeof params !== 'object') {
+    return null;
+  }
+
+  const p = params as Record<string, unknown>;
+
+  // Fallback chain: params.name ?? params.tool ?? params.toolName
+  if (typeof p.name === 'string' && p.name.length > 0) {
+    return p.name;
+  }
+  if (typeof p.tool === 'string' && p.tool.length > 0) {
+    return p.tool;
+  }
+  if (typeof p.toolName === 'string' && p.toolName.length > 0) {
+    return p.toolName;
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Method Distribution Computation
+// ============================================================================
+
+/**
+ * Compute method distribution for donut chart.
+ * Shows top 5 methods + "Others" bucket.
+ */
+function computeMethodDistribution(rpcs: SessionRpcDetail[]): HtmlMethodDistribution {
+  if (rpcs.length === 0) {
+    return {
+      slices: [],
+      total_rpcs: 0,
+    };
+  }
+
+  // Count by method
+  const methodCounts = new Map<string, number>();
+  for (const rpc of rpcs) {
+    methodCounts.set(rpc.method, (methodCounts.get(rpc.method) || 0) + 1);
+  }
+
+  // Sort by count descending
+  const sorted = Array.from(methodCounts.entries()).sort((a, b) => b[1] - a[1]);
+
+  const totalRpcs = rpcs.length;
+  const slices: HtmlMethodSlice[] = [];
+
+  // Take top 5
+  const top5 = sorted.slice(0, 5);
+  let top5Total = 0;
+
+  for (const [method, count] of top5) {
+    top5Total += count;
+    slices.push({
+      method,
+      count,
+      pct: Math.round((count / totalRpcs) * 100),
+    });
+  }
+
+  // Add "Others" if there are more than 5 methods
+  if (sorted.length > 5) {
+    const othersCount = totalRpcs - top5Total;
+    if (othersCount > 0) {
+      slices.push({
+        method: 'Others',
+        count: othersCount,
+        pct: Math.round((othersCount / totalRpcs) * 100),
+      });
+    }
+  }
+
+  return {
+    slices,
+    total_rpcs: totalRpcs,
+  };
+}

--- a/src/html/index.ts
+++ b/src/html/index.ts
@@ -36,6 +36,17 @@ export type {
   HtmlConnectorInfo,
   HtmlConnectorSessionRow,
   HtmlConnectorReportV1,
+  // Connector Analytics types (Phase 5.2)
+  HtmlConnectorKpis,
+  HtmlHeatmapCell,
+  HtmlHeatmapData,
+  HtmlLatencyBucket,
+  HtmlLatencyHistogram,
+  HtmlTopTool,
+  HtmlTopToolsData,
+  HtmlMethodSlice,
+  HtmlMethodDistribution,
+  HtmlConnectorAnalyticsV1,
 } from './types.js';
 
 // Templates
@@ -58,3 +69,6 @@ export {
   ensureOutputDir,
   safeWriteFile,
 } from './utils.js';
+
+// Analytics (Phase 5.2)
+export { computeConnectorAnalytics, LATENCY_BUCKETS, P95_MIN_SAMPLES } from './analytics.js';

--- a/src/html/templates.test.ts
+++ b/src/html/templates.test.ts
@@ -524,6 +524,57 @@ describe('generateConnectorHtml', () => {
         },
       },
     },
+    analytics: {
+      kpis: {
+        rpc_total: 5,
+        rpc_ok: 4,
+        rpc_err: 1,
+        rpc_pending: 0,
+        avg_latency_ms: 16,
+        p95_latency_ms: null,
+        max_latency_ms: 25,
+        total_request_bytes: 500,
+        total_response_bytes: 1000,
+        sessions_total: 10,
+        sessions_displayed: 2,
+        top_tool_name: 'read_file',
+        top_tool_calls: 3,
+      },
+      heatmap: {
+        start_date: '2025-01-12',
+        end_date: '2025-01-12',
+        cells: [{ date: '2025-01-12', count: 5 }],
+        max_count: 5,
+      },
+      latency: {
+        buckets: [
+          { label: '0-10', from_ms: 0, to_ms: 10, count: 2 },
+          { label: '10-25', from_ms: 10, to_ms: 25, count: 2 },
+          { label: '25-50', from_ms: 25, to_ms: 50, count: 1 },
+          { label: '50-100', from_ms: 50, to_ms: 100, count: 0 },
+          { label: '100-250', from_ms: 100, to_ms: 250, count: 0 },
+          { label: '250-500', from_ms: 250, to_ms: 500, count: 0 },
+          { label: '500-1000', from_ms: 500, to_ms: 1000, count: 0 },
+          { label: '1000+', from_ms: 1000, to_ms: null, count: 0 },
+        ],
+        sample_size: 5,
+        excluded_count: 0,
+      },
+      top_tools: {
+        items: [
+          { name: 'read_file', count: 3, pct: 60 },
+          { name: 'write_file', count: 2, pct: 40 },
+        ],
+        total_calls: 5,
+      },
+      method_distribution: {
+        slices: [
+          { method: 'tools/call', count: 3, pct: 60 },
+          { method: 'tools/list', count: 2, pct: 40 },
+        ],
+        total_rpcs: 5,
+      },
+    },
   };
 
   it('should generate valid HTML structure', () => {

--- a/src/html/templates.ts
+++ b/src/html/templates.ts
@@ -7,10 +7,16 @@
 
 import { formatBytes } from '../eventline/types.js';
 import type {
+  HtmlConnectorAnalyticsV1,
+  HtmlConnectorKpis,
   HtmlConnectorReportV1,
   HtmlConnectorSessionRow,
+  HtmlHeatmapData,
+  HtmlLatencyHistogram,
+  HtmlMethodDistribution,
   HtmlRpcReportV1,
   HtmlSessionReportV1,
+  HtmlTopToolsData,
   PayloadData,
   RpcStatus,
   SessionRpcDetail,
@@ -1140,6 +1146,226 @@ function getConnectorReportStyles(): string {
     .resize-handle:hover {
       background: var(--accent-blue);
     }
+
+    /* Analytics Panel (Phase 5.2) - Revised Layout */
+
+    /* Header with KPI stats inline */
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .header-left {
+      flex-shrink: 0;
+    }
+    .header-server-row {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+    }
+    .header-caps {
+      display: flex;
+      gap: 4px;
+    }
+    .header-server-info {
+      display: flex;
+      gap: 12px;
+      font-size: 0.75em;
+      color: var(--text-secondary);
+    }
+    .header-server-info .server-name {
+      color: var(--text-primary);
+    }
+    .header-label {
+      color: var(--text-secondary);
+      font-size: 0.9em;
+    }
+    .no-caps {
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+    .kpi-row {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      align-items: baseline;
+    }
+    .kpi-item {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0;
+      background: transparent;
+      min-width: 50px;
+    }
+    .kpi-item .kpi-value {
+      font-size: 0.95em;
+      font-weight: 600;
+      color: var(--accent-blue);
+      font-family: 'SFMono-Regular', Consolas, monospace;
+      line-height: 1.2;
+    }
+    .kpi-item .kpi-label {
+      font-size: 0.55em;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    /* All KPI values use accent-blue for unified appearance */
+
+    /* Connector top section: info + charts row */
+    .connector-top {
+      display: flex;
+      gap: 16px;
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border-color);
+      background: var(--bg-secondary);
+    }
+    .connector-top .connector-info {
+      flex: 0 0 360px;
+      max-width: 360px;
+      border-bottom: none;
+      padding: 0;
+    }
+    .analytics-panel {
+      flex: 1;
+      display: flex;
+      gap: 12px;
+      align-items: stretch;
+    }
+
+    /* Charts row - 4 items horizontal with custom flex ratios */
+    .heatmap-container {
+      flex: 0.8;
+      background: var(--bg-primary);
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+      padding: 8px;
+      min-width: 0;
+    }
+    .latency-histogram {
+      flex: 1.4;
+      background: var(--bg-primary);
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+      padding: 8px;
+      min-width: 0;
+    }
+    .top-tools, .method-distribution {
+      flex: 1;
+      background: var(--bg-primary);
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+      padding: 8px;
+      min-width: 0;
+    }
+    .chart-title {
+      font-size: 0.75em;
+      color: var(--text-secondary);
+      margin-bottom: 4px;
+    }
+
+    /* Heatmap - using neon blue gradient for consistency with theme */
+    .heatmap-title {
+      font-size: 0.75em;
+      color: var(--text-secondary);
+      margin-bottom: 4px;
+    }
+    .heatmap-level-0 { fill: var(--bg-tertiary); }
+    .heatmap-level-1 { fill: #0a3d4d; }
+    .heatmap-level-2 { fill: #0d5c73; }
+    .heatmap-level-3 { fill: #0097b2; }
+    .heatmap-level-4 { fill: #00d4ff; }
+
+    /* Histogram */
+    .histogram-bar { fill: var(--accent-blue); }
+    .histogram-label { fill: var(--text-secondary); font-size: 9px; }
+
+    /* Top Tools */
+    .top-tool-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 3px;
+      font-size: 0.75em;
+    }
+    .top-tool-rank {
+      color: var(--text-secondary);
+      width: 14px;
+      flex-shrink: 0;
+    }
+    .top-tool-name {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-family: 'SFMono-Regular', Consolas, monospace;
+    }
+    .top-tool-bar-container {
+      width: 50px;
+      height: 6px;
+      background: var(--bg-tertiary);
+      border-radius: 3px;
+      overflow: hidden;
+      flex-shrink: 0;
+    }
+    .top-tool-bar {
+      height: 100%;
+      background: var(--accent-blue);
+      border-radius: 3px;
+    }
+    .top-tool-pct {
+      color: var(--text-secondary);
+      width: 28px;
+      text-align: right;
+      flex-shrink: 0;
+    }
+    .no-data-message {
+      color: var(--text-secondary);
+      font-size: 0.75em;
+      text-align: center;
+      padding: 8px;
+    }
+
+    /* Method Distribution Donut Chart */
+    .donut-container {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .donut-legend {
+      flex: 1;
+      font-size: 0.7em;
+      min-width: 0;
+    }
+    .donut-legend-item {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin-bottom: 2px;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    .donut-legend-color {
+      width: 8px;
+      height: 8px;
+      border-radius: 2px;
+      flex-shrink: 0;
+    }
+    .donut-legend-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      flex: 1;
+      min-width: 0;
+    }
+    .donut-legend-pct {
+      color: var(--text-secondary);
+      flex-shrink: 0;
+    }
   `;
 }
 
@@ -1376,6 +1602,321 @@ function getConnectorReportScript(): string {
   `;
 }
 
+// ============================================================================
+// Analytics Panel Rendering (Phase 5.2)
+// ============================================================================
+
+/**
+ * Render KPI stats row for header (inline compact display)
+ */
+function renderKpiRow(kpis: HtmlConnectorKpis): string {
+  // Format large numbers with K/M suffix
+  const formatNumber = (n: number): string => {
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+    if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+    return String(n);
+  };
+
+  // Format bytes for display
+  const formatBytesCompact = (bytes: number): string => {
+    if (bytes === 0) return '0';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + sizes[i];
+  };
+
+  return `
+    <div class="kpi-row">
+      <div class="kpi-item">
+        <div class="kpi-value">${formatNumber(kpis.sessions_displayed)}</div>
+        <div class="kpi-label">Sessions</div>
+      </div>
+      <div class="kpi-item">
+        <div class="kpi-value">${formatNumber(kpis.rpc_total)}</div>
+        <div class="kpi-label">RPCs</div>
+      </div>
+      <div class="kpi-item">
+        <div class="kpi-value">${formatNumber(kpis.rpc_err)}</div>
+        <div class="kpi-label">Error</div>
+      </div>
+      <div class="kpi-item">
+        <div class="kpi-value">${kpis.avg_latency_ms !== null ? kpis.avg_latency_ms : '-'}</div>
+        <div class="kpi-label">Avg Latency</div>
+      </div>
+      <div class="kpi-item">
+        <div class="kpi-value">${kpis.p95_latency_ms !== null ? kpis.p95_latency_ms : '-'}</div>
+        <div class="kpi-label">P95 Latency</div>
+      </div>
+      <div class="kpi-item">
+        <div class="kpi-value">${formatBytesCompact(kpis.total_request_bytes)}</div>
+        <div class="kpi-label">Req Size</div>
+      </div>
+      <div class="kpi-item">
+        <div class="kpi-value">${formatBytesCompact(kpis.total_response_bytes)}</div>
+        <div class="kpi-label">Res Size</div>
+      </div>
+    </div>`;
+}
+
+/**
+ * Get intensity level (0-4) for heatmap cell based on count and max
+ */
+function getHeatmapLevel(count: number, maxCount: number): number {
+  if (count === 0 || maxCount === 0) return 0;
+  const ratio = count / maxCount;
+  if (ratio <= 0.25) return 1;
+  if (ratio <= 0.5) return 2;
+  if (ratio <= 0.75) return 3;
+  return 4;
+}
+
+/**
+ * Render activity heatmap (GitHub contributions style, SVG)
+ */
+function renderHeatmap(heatmap: HtmlHeatmapData): string {
+  const cellSize = 10;
+  const cellGap = 2;
+  const cellTotal = cellSize + cellGap;
+
+  // Group cells by week (7 days per column)
+  const weeks: Array<typeof heatmap.cells> = [];
+  let currentWeek: typeof heatmap.cells = [];
+
+  // Find the day of week for the start date (0 = Sunday)
+  const startDow = new Date(heatmap.start_date + 'T00:00:00Z').getUTCDay();
+
+  // Add empty cells for days before start_date
+  for (let i = 0; i < startDow; i++) {
+    currentWeek.push({ date: '', count: -1 }); // -1 indicates empty
+  }
+
+  for (const cell of heatmap.cells) {
+    currentWeek.push(cell);
+    if (currentWeek.length === 7) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+  }
+  if (currentWeek.length > 0) {
+    weeks.push(currentWeek);
+  }
+
+  // Calculate SVG dimensions
+  const svgWidth = weeks.length * cellTotal;
+  const svgHeight = 7 * cellTotal;
+
+  // Generate SVG rects
+  let rects = '';
+  weeks.forEach((week, weekIdx) => {
+    week.forEach((cell, dayIdx) => {
+      if (cell.count < 0) return; // Skip empty cells
+      const level = getHeatmapLevel(cell.count, heatmap.max_count);
+      const x = weekIdx * cellTotal;
+      const y = dayIdx * cellTotal;
+      const title = cell.date ? `${cell.date}: ${cell.count} RPCs` : '';
+      rects += `<rect x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="2" class="heatmap-level-${level}"><title>${escapeHtml(title)}</title></rect>`;
+    });
+  });
+
+  return `
+    <div class="heatmap-container">
+      <div class="heatmap-title">Activity (${escapeHtml(heatmap.start_date)} to ${escapeHtml(heatmap.end_date)})</div>
+      <svg width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}">
+        ${rects}
+      </svg>
+    </div>`;
+}
+
+/**
+ * Render latency histogram (SVG bar chart)
+ */
+function renderLatencyHistogram(latency: HtmlLatencyHistogram): string {
+  if (latency.sample_size === 0) {
+    return `
+      <div class="latency-histogram">
+        <div class="chart-title">Latency Distribution</div>
+        <div class="no-data-message">No latency data</div>
+      </div>`;
+  }
+
+  const maxCount = Math.max(...latency.buckets.map((b) => b.count), 1);
+  const barWidth = 30;
+  const barGap = 4;
+  const chartWidth = latency.buckets.length * (barWidth + barGap);
+  const chartHeight = 60;
+  const labelHeight = 16;
+
+  let bars = '';
+  latency.buckets.forEach((bucket, idx) => {
+    const barHeight = maxCount > 0 ? (bucket.count / maxCount) * chartHeight : 0;
+    const x = idx * (barWidth + barGap);
+    const y = chartHeight - barHeight;
+    const title = `${bucket.label}ms: ${bucket.count} RPCs`;
+
+    bars += `<rect x="${x}" y="${y}" width="${barWidth}" height="${barHeight}" class="histogram-bar"><title>${escapeHtml(title)}</title></rect>`;
+    bars += `<text x="${x + barWidth / 2}" y="${chartHeight + labelHeight - 4}" text-anchor="middle" class="histogram-label">${escapeHtml(bucket.label)}</text>`;
+  });
+
+  return `
+    <div class="latency-histogram">
+      <div class="chart-title">Latency Distribution (${latency.sample_size} samples)</div>
+      <svg width="${chartWidth}" height="${chartHeight + labelHeight}" viewBox="0 0 ${chartWidth} ${chartHeight + labelHeight}">
+        ${bars}
+      </svg>
+    </div>`;
+}
+
+/**
+ * Render top 5 tools
+ */
+function renderTopTools(topTools: HtmlTopToolsData): string {
+  if (topTools.items.length === 0) {
+    return `
+      <div class="top-tools">
+        <div class="chart-title">Top Tools</div>
+        <div class="no-data-message">No tool calls</div>
+      </div>`;
+  }
+
+  const rows = topTools.items
+    .map((tool, idx) => {
+      return `
+      <div class="top-tool-row">
+        <span class="top-tool-rank">${idx + 1}.</span>
+        <span class="top-tool-name" title="${escapeHtml(tool.name)}">${escapeHtml(tool.name)}</span>
+        <div class="top-tool-bar-container">
+          <div class="top-tool-bar" style="width: ${tool.pct}%"></div>
+        </div>
+        <span class="top-tool-pct">${tool.pct}%</span>
+      </div>`;
+    })
+    .join('');
+
+  return `
+    <div class="top-tools">
+      <div class="chart-title">Top Tools (${topTools.total_calls} calls)</div>
+      ${rows}
+    </div>`;
+}
+
+/**
+ * Donut chart colors (blue gradient palette)
+ */
+const DONUT_COLORS = [
+  '#00d4ff',  // Neon blue (brightest)
+  '#0097b2',  // Medium bright blue
+  '#0d5c73',  // Medium blue
+  '#0a4d5c',  // Darker blue
+  '#083d47',  // Dark blue
+  '#5a6a70',  // Blue-gray (for "Others")
+];
+
+/**
+ * Render method distribution donut chart (SVG)
+ */
+function renderMethodDistribution(methodDist: HtmlMethodDistribution): string {
+  if (methodDist.slices.length === 0) {
+    return `
+      <div class="method-distribution">
+        <div class="chart-title">Method Distribution</div>
+        <div class="no-data-message">No RPCs</div>
+      </div>`;
+  }
+
+  // SVG donut chart parameters
+  const size = 60;
+  const cx = size / 2;
+  const cy = size / 2;
+  const outerRadius = 26;
+  const innerRadius = 16; // Creates the donut hole
+
+  // Generate SVG path segments
+  let paths = '';
+  let currentAngle = -90; // Start from top (12 o'clock)
+
+  methodDist.slices.forEach((slice, idx) => {
+    const angle = (slice.pct / 100) * 360;
+    const startAngle = currentAngle;
+    const endAngle = currentAngle + angle;
+
+    // Convert angles to radians
+    const startRad = (startAngle * Math.PI) / 180;
+    const endRad = (endAngle * Math.PI) / 180;
+
+    // Calculate arc points for outer radius
+    const x1Outer = cx + outerRadius * Math.cos(startRad);
+    const y1Outer = cy + outerRadius * Math.sin(startRad);
+    const x2Outer = cx + outerRadius * Math.cos(endRad);
+    const y2Outer = cy + outerRadius * Math.sin(endRad);
+
+    // Calculate arc points for inner radius
+    const x1Inner = cx + innerRadius * Math.cos(endRad);
+    const y1Inner = cy + innerRadius * Math.sin(endRad);
+    const x2Inner = cx + innerRadius * Math.cos(startRad);
+    const y2Inner = cy + innerRadius * Math.sin(startRad);
+
+    // Large arc flag
+    const largeArc = angle > 180 ? 1 : 0;
+
+    // Color
+    const color = DONUT_COLORS[idx % DONUT_COLORS.length];
+
+    // SVG path for donut segment
+    const d = [
+      `M ${x1Outer} ${y1Outer}`,                                    // Start at outer edge
+      `A ${outerRadius} ${outerRadius} 0 ${largeArc} 1 ${x2Outer} ${y2Outer}`, // Outer arc
+      `L ${x1Inner} ${y1Inner}`,                                    // Line to inner edge
+      `A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${x2Inner} ${y2Inner}`, // Inner arc (reverse)
+      'Z',                                                          // Close path
+    ].join(' ');
+
+    const title = `${slice.method}: ${slice.count} (${slice.pct}%)`;
+    paths += `<path d="${d}" fill="${color}"><title>${escapeHtml(title)}</title></path>`;
+
+    currentAngle = endAngle;
+  });
+
+  // Generate legend
+  const legendItems = methodDist.slices
+    .map((slice, idx) => {
+      const color = DONUT_COLORS[idx % DONUT_COLORS.length];
+      return `
+      <div class="donut-legend-item">
+        <div class="donut-legend-color" style="background: ${color}"></div>
+        <span class="donut-legend-label" title="${escapeHtml(slice.method)}">${escapeHtml(slice.method)}</span>
+        <span class="donut-legend-pct">${slice.pct}%</span>
+      </div>`;
+    })
+    .join('');
+
+  return `
+    <div class="method-distribution">
+      <div class="chart-title">Methods (${methodDist.total_rpcs} RPCs)</div>
+      <div class="donut-container">
+        <svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
+          ${paths}
+        </svg>
+        <div class="donut-legend">
+          ${legendItems}
+        </div>
+      </div>
+    </div>`;
+}
+
+/**
+ * Render the analytics panel (4 charts horizontally)
+ */
+function renderAnalyticsPanel(analytics: HtmlConnectorAnalyticsV1): string {
+  return `
+    <div class="analytics-panel">
+      ${renderHeatmap(analytics.heatmap)}
+      ${renderLatencyHistogram(analytics.latency)}
+      ${renderTopTools(analytics.top_tools)}
+      ${renderMethodDistribution(analytics.method_distribution)}
+    </div>`;
+}
+
 /**
  * Render a session item for the sessions pane
  */
@@ -1484,7 +2025,7 @@ ${rpcRows}
  * Generate Connector HTML report (3-hierarchy: Connector -> Sessions -> RPCs)
  */
 export function generateConnectorHtml(report: HtmlConnectorReportV1): string {
-  const { meta, connector, sessions, session_reports } = report;
+  const { meta, connector, sessions, session_reports, analytics } = report;
 
   // Pagination info
   const fromNum = connector.offset + 1;
@@ -1498,8 +2039,8 @@ export function generateConnectorHtml(report: HtmlConnectorReportV1): string {
     ? connector.transport.command || '(unknown command)'
     : connector.transport.url || '(unknown URL)';
 
-  // Server info (if available)
-  let serverInfoHtml = '';
+  // Server info for header (if available)
+  let headerServerHtml = '';
   if (connector.server) {
     const { name, version, protocolVersion, capabilities } = connector.server;
     const serverName = name || '(unknown)';
@@ -1511,15 +2052,16 @@ export function generateConnectorHtml(report: HtmlConnectorReportV1): string {
     if (capabilities.tools) capBadges.push('<span class="badge cap-enabled">tools</span>');
     if (capabilities.resources) capBadges.push('<span class="badge cap-enabled">resources</span>');
     if (capabilities.prompts) capBadges.push('<span class="badge cap-enabled">prompts</span>');
-    const capsDisplay = capBadges.length > 0 ? capBadges.join(' ') : '<span style="color: var(--text-secondary)">(none)</span>';
+    const capsDisplay = capBadges.length > 0 ? capBadges.join(' ') : '';
 
-    serverInfoHtml = `
-        <dt>Server</dt>
-        <dd>${escapeHtml(serverName)} ${escapeHtml(serverVersion)}</dd>
-        <dt>Protocol</dt>
-        <dd>${escapeHtml(protocolDisplay)}</dd>
-        <dt>Capabilities</dt>
-        <dd class="capabilities">${capsDisplay}</dd>`;
+    headerServerHtml = `
+    <div class="header-server-row">
+      <div class="header-caps"><span class="header-label">Capabilities:</span> ${capsDisplay || '<span class="no-caps">(none)</span>'}</div>
+      <div class="header-server-info">
+        <span class="server-name"><span class="header-label">Server:</span> ${escapeHtml(serverName)} ${escapeHtml(serverVersion)}</span>
+        <span class="server-protocol"><span class="header-label">Protocol:</span> ${escapeHtml(protocolDisplay)}</span>
+      </div>
+    </div>`;
   }
 
   // Session items
@@ -1544,26 +2086,32 @@ export function generateConnectorHtml(report: HtmlConnectorReportV1): string {
 </head>
 <body>
   <header>
-    <h1>Connector: <span class="badge">${escapeHtml(connector.connector_id)}</span></h1>
-    <p class="meta">Generated by ${escapeHtml(meta.generatedBy)} at ${formatTimestamp(meta.generatedAt)}${meta.redacted ? ' (redacted)' : ''} | ${paginationInfo}</p>
+    <div class="header-left">
+      <h1>Connector: <span class="badge">${escapeHtml(connector.connector_id)}</span></h1>
+      <p class="meta">Generated by ${escapeHtml(meta.generatedBy)} at ${formatTimestamp(meta.generatedAt)}${meta.redacted ? ' (redacted)' : ''} | ${paginationInfo}</p>
+    </div>
+    ${headerServerHtml}
+    ${renderKpiRow(analytics.kpis)}
   </header>
 
-  <div class="connector-info expanded">
-    <div class="connector-info-toggle">
-      <h2>Connector Info</h2>
-      <span class="toggle-icon">▼</span>
+  <div class="connector-top">
+    <div class="connector-info expanded">
+      <div class="connector-info-toggle">
+        <h2>Connector Info</h2>
+        <span class="toggle-icon">▼</span>
+      </div>
+      <div class="connector-info-content">
+        <dl>
+          <dt>Transport</dt>
+          <dd><span class="badge">${escapeHtml(connector.transport.type)}</span></dd>
+          <dt>${connector.transport.type === 'stdio' ? 'Command' : 'URL'}</dt>
+          <dd><code>${escapeHtml(transportDisplay)}</code></dd>
+          <dt>Enabled</dt>
+          <dd>${connector.enabled ? '<span class="badge status-OK">yes</span>' : '<span class="badge status-ERR">no</span>'}</dd>
+        </dl>
+      </div>
     </div>
-    <div class="connector-info-content">
-      <dl>
-        <dt>Transport</dt>
-        <dd><span class="badge">${escapeHtml(connector.transport.type)}</span></dd>
-        <dt>${connector.transport.type === 'stdio' ? 'Command' : 'URL'}</dt>
-        <dd><code>${escapeHtml(transportDisplay)}</code></dd>
-        <dt>Enabled</dt>
-        <dd>${connector.enabled ? '<span class="badge status-OK">yes</span>' : '<span class="badge status-ERR">no</span>'}</dd>
-${serverInfoHtml}
-      </dl>
-    </div>
+    ${renderAnalyticsPanel(analytics)}
   </div>
 
   <div class="main-container">

--- a/src/html/types.ts
+++ b/src/html/types.ts
@@ -303,6 +303,8 @@ export interface HtmlConnectorReportV1 {
   sessions: HtmlConnectorSessionRow[];
   /** セッション詳細（右ペイン用）- session_id をキーとするマップ */
   session_reports: Record<string, HtmlSessionReportV1>;
+  /** Analytics data (Phase 5.2) */
+  analytics: HtmlConnectorAnalyticsV1;
 }
 
 /**
@@ -312,4 +314,109 @@ export interface HtmlConnectorReportV1 {
 export function getConnectorHtmlFilename(connectorId: string): string {
   const sanitized = connectorId.replace(/[^a-zA-Z0-9-_]/g, '-');
   return `connector_${sanitized}.html`;
+}
+
+// ============================================================================
+// Connector HTML Analytics Types (Phase 5.2)
+// ============================================================================
+
+/**
+ * Connector-level KPIs
+ */
+export interface HtmlConnectorKpis {
+  rpc_total: number;
+  rpc_ok: number;
+  rpc_err: number;
+  rpc_pending: number;
+  avg_latency_ms: number | null;    // null if no RPCs with latency
+  p95_latency_ms: number | null;    // null if < 20 samples (nearest-rank method)
+  max_latency_ms: number | null;
+  total_request_bytes: number;
+  total_response_bytes: number;
+  sessions_total: number;
+  sessions_displayed: number;
+  top_tool_name: string | null;
+  top_tool_calls: number | null;
+}
+
+/**
+ * Heatmap cell (GitHub contributions style)
+ */
+export interface HtmlHeatmapCell {
+  date: string;    // YYYY-MM-DD (UTC)
+  count: number;   // RPC count
+}
+
+/**
+ * Heatmap data with intensity calculation
+ */
+export interface HtmlHeatmapData {
+  start_date: string;
+  end_date: string;
+  cells: HtmlHeatmapCell[];   // Full range including 0-count days
+  max_count: number;          // For intensity scaling
+}
+
+/**
+ * Latency histogram bucket
+ */
+export interface HtmlLatencyBucket {
+  label: string;      // e.g., "0-10", "1000+"
+  from_ms: number;
+  to_ms: number | null;  // null = +∞ (for "1000+" bucket)
+  count: number;
+}
+
+/**
+ * Latency histogram data
+ */
+export interface HtmlLatencyHistogram {
+  buckets: HtmlLatencyBucket[];
+  sample_size: number;      // RPCs with latency_ms
+  excluded_count: number;   // RPCs without latency_ms
+}
+
+/**
+ * Top tool entry
+ */
+export interface HtmlTopTool {
+  name: string;
+  count: number;
+  pct: number;    // 0-100
+}
+
+/**
+ * Top tools data
+ */
+export interface HtmlTopToolsData {
+  items: HtmlTopTool[];   // Top 5
+  total_calls: number;    // Total tools/call count
+}
+
+/**
+ * Method distribution slice (for donut chart)
+ */
+export interface HtmlMethodSlice {
+  method: string;
+  count: number;
+  pct: number;    // 0-100
+}
+
+/**
+ * Method distribution data
+ */
+export interface HtmlMethodDistribution {
+  slices: HtmlMethodSlice[];   // Top 5 methods + "Others"
+  total_rpcs: number;
+}
+
+/**
+ * Complete analytics data
+ */
+export interface HtmlConnectorAnalyticsV1 {
+  kpis: HtmlConnectorKpis;
+  heatmap: HtmlHeatmapData;
+  latency: HtmlLatencyHistogram;
+  top_tools: HtmlTopToolsData;
+  method_distribution: HtmlMethodDistribution;
 }


### PR DESCRIPTION
## Summary

- Add comprehensive analytics visualization to connector HTML reports (Phase 5.2)
- KPI row displays: Sessions, RPCs, Error, Avg Latency, P95 Latency, Req Size, Res Size
- Activity Heatmap: GitHub-style SVG heatmap showing RPC activity by UTC date
- Latency Histogram: SVG bar chart with 8 fixed buckets (0-10ms to 1000+ms)
- Top 5 Tools: Ranked list of most-called tools with percentage bars
- Method Distribution: SVG donut chart showing RPC method breakdown (top 5 + Others)
- All charts use blue gradient color palette matching the dark theme

## Test plan

- [x] All 1119 tests pass
- [x] TypeScript build succeeds
- [ ] Manual test: `pfs connectors show --id <connector> --html --open`
- [ ] Verify KPI row shows correct counts
- [ ] Verify heatmap shows activity pattern
- [ ] Verify latency histogram shows distribution
- [ ] Verify top tools shows ranked list
- [ ] Verify method distribution donut chart renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)