### PR TITLE
style: adjust layout widths for better readability (Phase 12.x-b)

### DIFF
--- a/src/html/rpc-inspector.ts
+++ b/src/html/rpc-inspector.ts
@@ -1071,6 +1071,7 @@ export function getRpcInspectorStyles(): string {
 
     .rpc-inspector-raw {
       flex: 1;
+      max-width: var(--raw-pane-max-width, 480px);
       display: flex;
       flex-direction: column;
       min-width: 0;

--- a/src/html/templates.ts
+++ b/src/html/templates.ts
@@ -872,8 +872,9 @@ function getConnectorReportStyles(): string {
       --status-pending: #d29922;
       --border-color: #30363d;
       --link-color: #58a6ff;
-      --sessions-pane-width: 280px;
-      --left-pane-width: 420px;
+      --sessions-pane-width: 360px;
+      --left-pane-width: 480px;
+      --raw-pane-max-width: 480px;
     }
     * { box-sizing: border-box; }
     html, body {


### PR DESCRIPTION
## Summary

- Increase sessions pane width: 280px → 360px
- Increase left pane width: 420px → 480px  
- Add max-width constraint to RAW JSON pane: 480px

## Rationale

This gives more space to the sessions list and summary views while preventing the RAW JSON pane from taking excessive horizontal space on wide monitors.

## Files Changed

| File | Change |
|------|--------|
| `src/html/templates.ts` | Update CSS variables for pane widths |
| `src/html/rpc-inspector.ts` | Add `max-width` constraint to RAW pane |

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All tests pass (`npm test`)
- [ ] Sessions pane has more horizontal space
- [ ] RAW JSON pane does not expand beyond 480px

🤖 Generated with [Claude Code](https://claude.com/claude-code)