### PR TITLE
feat(html): compact session grid view (Phase 12.x)

### DIFF
--- a/src/html/templates.test.ts
+++ b/src/html/templates.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import {
   escapeHtml,
   escapeJsonForScript,
+  formatCompactTimestamp,
   generateRpcHtml,
   generateSessionHtml,
   generateConnectorHtml,
@@ -810,5 +811,52 @@ describe('generateConnectorHtml', () => {
     };
     const html = generateConnectorHtml(offsetReport);
     expect(html).toContain('Showing 51-100 of 100 sessions');
+  });
+});
+
+describe('formatCompactTimestamp', () => {
+  it('should format valid UTC timestamp as MM/DD HH:MM', () => {
+    // 2025-01-12T14:30:45.000Z in UTC
+    const result = formatCompactTimestamp('2025-01-12T14:30:45.000Z');
+    expect(result).toBe('01/12 14:30');
+  });
+
+  it('should pad single digit months and days with zeros', () => {
+    const result = formatCompactTimestamp('2025-03-05T08:09:00.000Z');
+    expect(result).toBe('03/05 08:09');
+  });
+
+  it('should handle midnight correctly', () => {
+    const result = formatCompactTimestamp('2025-12-31T00:00:00.000Z');
+    expect(result).toBe('12/31 00:00');
+  });
+
+  it('should handle end of day correctly', () => {
+    const result = formatCompactTimestamp('2025-06-15T23:59:59.999Z');
+    expect(result).toBe('06/15 23:59');
+  });
+
+  it('should return "-" for invalid timestamp', () => {
+    expect(formatCompactTimestamp('invalid')).toBe('-');
+    expect(formatCompactTimestamp('not-a-date')).toBe('-');
+  });
+
+  it('should return "-" for empty string', () => {
+    expect(formatCompactTimestamp('')).toBe('-');
+  });
+
+  it('should handle timestamp without Z suffix', () => {
+    // ISO 8601 without timezone is parsed as local time by Date
+    // But our function uses UTC methods, so output depends on input interpretation
+    const result = formatCompactTimestamp('2025-07-20T12:00:00Z');
+    expect(result).toBe('07/20 12:00');
+  });
+
+  it('should use UTC timezone consistently', () => {
+    // Verify that the same UTC timestamp always produces the same output
+    // regardless of local timezone (this tests the getUTC* methods are used)
+    const timestamp = '2025-01-15T23:45:30.000Z';
+    const result = formatCompactTimestamp(timestamp);
+    expect(result).toBe('01/15 23:45');
   });
 });

--- a/src/html/templates.ts
+++ b/src/html/templates.ts
@@ -1123,7 +1123,7 @@ function getConnectorReportStyles(): string {
     }
     .sessions-header-row {
       display: grid;
-      grid-template-columns: 80px 1fr 50px 70px 40px;
+      grid-template-columns: 80px 1fr 50px 70px 50px;
       gap: 8px;
       padding: 4px 8px;
       font-size: 10px;
@@ -1134,7 +1134,7 @@ function getConnectorReportStyles(): string {
     }
     .session-item {
       display: grid;
-      grid-template-columns: 80px 1fr 50px 70px 40px;
+      grid-template-columns: 80px 1fr 50px 70px 50px;
       gap: 8px;
       align-items: center;
       padding: 6px 8px;
@@ -2317,15 +2317,20 @@ function renderConnectorSessionItem(session: HtmlConnectorSessionRow): string {
 }
 
 /**
- * Format timestamp compactly for grid display
+ * Format timestamp compactly for grid display (UTC)
+ * Returns format: MM/DD HH:MM
+ * @public - exported for testing
  */
-function formatCompactTimestamp(isoStr: string): string {
+export function formatCompactTimestamp(isoStr: string): string {
   try {
     const date = new Date(isoStr);
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
+    if (isNaN(date.getTime())) {
+      return '-';
+    }
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    const hours = String(date.getUTCHours()).padStart(2, '0');
+    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
     return `${month}/${day} ${hours}:${minutes}`;
   } catch {
     return '-';
@@ -2565,10 +2570,10 @@ export function generateConnectorHtml(report: HtmlConnectorReportV1): string {
       </div>
       <div class="sessions-header-row">
         <span>ID</span>
-        <span>Timestamp</span>
+        <span>Time (UTC)</span>
         <span style="text-align:right">RPCs</span>
         <span style="text-align:right">Latency</span>
-        <span style="text-align:center">St</span>
+        <span style="text-align:center">Status</span>
       </div>
       <div class="sessions-list">
 ${sessionItems}


### PR DESCRIPTION
## Summary

- Sessions list now uses 1-row-per-session grid layout for compact display
- Column headers: ID, Timestamp, RPCs, Latency, Status
- Compact font sizes and padding for denser information display
- New `formatCompactTimestamp` helper for MM/DD HH:MM format
- Latency displayed directly in session row

## Changes

| Before | After |
|--------|-------|
| Multi-row session cards | Single-row grid items |
| Date + Time separate lines | Compact MM/DD HH:MM |
| RPCs + errors verbose | Numeric-only columns |

## Test plan

- [ ] Build passes
- [ ] All tests pass (1161)
- [ ] Session list displays as compact grid
- [ ] Column headers visible above list
- [ ] Session selection still works
- [ ] Scrolling works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)