### PR TITLE
feat(shell): Add TAB completion for configure mode

### DIFF
--- a/src/shell/configure/completer.test.ts
+++ b/src/shell/configure/completer.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for configure mode TAB completion
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getConfigureCompletions, type ConfigureDataProvider } from './completer.js';
+import { ConfigureMode } from './mode.js';
+import { ConfigManager } from '../../config/index.js';
+
+// Mock ConfigManager
+vi.mock('../../config/index.js', () => ({
+  ConfigManager: vi.fn().mockImplementation(() => ({
+    load: vi.fn().mockResolvedValue({ connectors: [] }),
+    getConfigDir: vi.fn().mockReturnValue('/tmp/test-config'),
+    addConnector: vi.fn(),
+    updateConnector: vi.fn(),
+  })),
+}));
+
+// Mock IPC client
+vi.mock('../../proxy/ipc-client.js', () => ({
+  IpcClient: vi.fn().mockImplementation(() => ({
+    isRunning: vi.fn().mockResolvedValue(false),
+    reload: vi.fn().mockResolvedValue({ success: true }),
+  })),
+}));
+
+vi.mock('../../proxy/ipc-types.js', () => ({
+  getSocketPath: vi.fn().mockReturnValue('/tmp/test.sock'),
+}));
+
+// Mock data provider
+function createMockDataProvider(): ConfigureDataProvider {
+  return {
+    getConnectorIds: vi.fn(() => ['mcp-server', 'my-connector', 'test-conn']),
+  };
+}
+
+describe('getConfigureCompletions', () => {
+  let mode: ConfigureMode;
+  let dataProvider: ConfigureDataProvider;
+
+  beforeEach(() => {
+    const mockConfigManager = new ConfigManager('/tmp/test');
+    mode = new ConfigureMode(mockConfigManager);
+    dataProvider = createMockDataProvider();
+  });
+
+  describe('root level (not editing)', () => {
+    beforeEach(() => {
+      mode.enter();
+    });
+
+    it('should return root commands on empty line', () => {
+      const [completions] = getConfigureCompletions('', mode, dataProvider);
+
+      expect(completions).toContain('connector');
+      expect(completions).toContain('edit');
+      expect(completions).toContain('ls');
+      expect(completions).toContain('exit');
+      expect(completions).toContain('help');
+    });
+
+    it('should complete partial command', () => {
+      const [completions, prefix] = getConfigureCompletions('con', mode, dataProvider);
+
+      expect(prefix).toBe('con');
+      expect(completions).toContain('connector');
+      expect(completions).not.toContain('exit');
+    });
+
+    it('should complete connector ids after "connector "', () => {
+      const [completions] = getConfigureCompletions('connector ', mode, dataProvider);
+
+      expect(completions).toContain('mcp-server');
+      expect(completions).toContain('my-connector');
+      expect(completions).toContain('test-conn');
+    });
+
+    it('should complete "connector" after "edit "', () => {
+      const [completions] = getConfigureCompletions('edit ', mode, dataProvider);
+
+      expect(completions).toContain('connector');
+    });
+
+    it('should complete connector ids after "edit connector "', () => {
+      const [completions] = getConfigureCompletions('edit connector ', mode, dataProvider);
+
+      expect(completions).toContain('mcp-server');
+      expect(completions).toContain('my-connector');
+    });
+
+    it('should complete ls options', () => {
+      const [completions] = getConfigureCompletions('ls ', mode, dataProvider);
+
+      expect(completions).toContain('--detail');
+    });
+
+    it('should complete help with root commands', () => {
+      const [completions] = getConfigureCompletions('help ', mode, dataProvider);
+
+      expect(completions).toContain('connector');
+      expect(completions).toContain('edit');
+      expect(completions).toContain('exit');
+    });
+  });
+
+  describe('edit session (editing connector)', () => {
+    beforeEach(async () => {
+      mode.enter();
+      await mode.editConnector('test-connector');
+    });
+
+    it('should return edit session commands on empty line', () => {
+      const [completions] = getConfigureCompletions('', mode, dataProvider);
+
+      expect(completions).toContain('set');
+      expect(completions).toContain('unset');
+      expect(completions).toContain('show');
+      expect(completions).toContain('commit');
+      expect(completions).toContain('discard');
+      expect(completions).toContain('exit');
+      expect(completions).toContain('help');
+    });
+
+    it('should complete partial command', () => {
+      const [completions, prefix] = getConfigureCompletions('se', mode, dataProvider);
+
+      expect(prefix).toBe('se');
+      expect(completions).toContain('set');
+      expect(completions).not.toContain('show');
+    });
+
+    describe('set command', () => {
+      it('should complete field paths after "set "', () => {
+        const [completions] = getConfigureCompletions('set ', mode, dataProvider);
+
+        expect(completions).toContain('enabled');
+        expect(completions).toContain('command');
+        expect(completions).toContain('cwd');
+        expect(completions).toContain('args');
+        expect(completions).toContain('args[0]');
+      });
+
+      it('should complete partial field path', () => {
+        const [completions, prefix] = getConfigureCompletions('set en', mode, dataProvider);
+
+        expect(prefix).toBe('en');
+        expect(completions).toContain('enabled');
+        expect(completions).not.toContain('command');
+      });
+
+      it('should suggest true/false for "set enabled "', () => {
+        const [completions] = getConfigureCompletions('set enabled ', mode, dataProvider);
+
+        expect(completions).toContain('true');
+        expect(completions).toContain('false');
+      });
+
+      it('should suggest common commands for "set command "', () => {
+        const [completions] = getConfigureCompletions('set command ', mode, dataProvider);
+
+        expect(completions).toContain('npx');
+        expect(completions).toContain('uvx');
+        expect(completions).toContain('node');
+        expect(completions).toContain('python');
+      });
+
+      it('should suggest --secret after value', () => {
+        const [completions] = getConfigureCompletions('set env.API_KEY myvalue ', mode, dataProvider);
+
+        expect(completions).toContain('--secret');
+      });
+
+      it('should not suggest --secret if already used', () => {
+        const [completions] = getConfigureCompletions('set env.API_KEY myvalue --secret ', mode, dataProvider);
+
+        expect(completions).not.toContain('--secret');
+      });
+
+      it('should suggest common env vars for env path', () => {
+        const [completions] = getConfigureCompletions('set env.', mode, dataProvider);
+
+        expect(completions.some(c => c.startsWith('env.'))).toBe(true);
+      });
+    });
+
+    describe('unset command', () => {
+      it('should return empty list for new connector with no optional fields set', () => {
+        const [completions] = getConfigureCompletions('unset ', mode, dataProvider);
+
+        // New connector has no optional fields set, so nothing to unset
+        // (enabled and command cannot be unset)
+        expect(completions).toEqual([]);
+      });
+    });
+
+    describe('show command', () => {
+      it('should complete show options', () => {
+        const [completions] = getConfigureCompletions('show ', mode, dataProvider);
+
+        expect(completions).toContain('--json');
+        expect(completions).toContain('candidate-config');
+        expect(completions).toContain('diff');
+      });
+    });
+
+    describe('commit command', () => {
+      it('should complete commit options', () => {
+        const [completions] = getConfigureCompletions('commit ', mode, dataProvider);
+
+        expect(completions).toContain('--dry-run');
+        expect(completions).toContain('--no-reload');
+      });
+
+      it('should filter already used options', () => {
+        const [completions] = getConfigureCompletions('commit --dry-run ', mode, dataProvider);
+
+        expect(completions).not.toContain('--dry-run');
+        expect(completions).toContain('--no-reload');
+      });
+    });
+
+    describe('help command', () => {
+      it('should complete help with edit session commands', () => {
+        const [completions] = getConfigureCompletions('help ', mode, dataProvider);
+
+        expect(completions).toContain('set');
+        expect(completions).toContain('unset');
+        expect(completions).toContain('commit');
+      });
+    });
+  });
+
+  describe('with existing connector data', () => {
+    beforeEach(async () => {
+      mode.enter();
+      await mode.editConnector('test-connector');
+
+      // Set some values on the connector
+      const manager = mode.getSessionManager()!;
+      manager.set('command', 'npx');
+      manager.set('cwd', '/tmp/test');
+      manager.set('args[0]', '-y');
+      manager.set('args[1]', 'some-package');
+      manager.set('env.MY_VAR', 'value');
+    });
+
+    it('should suggest current env vars', () => {
+      const [completions] = getConfigureCompletions('set env.', mode, dataProvider);
+
+      expect(completions).toContain('env.MY_VAR');
+    });
+
+    it('should suggest existing args indices', () => {
+      const [completions] = getConfigureCompletions('set args', mode, dataProvider);
+
+      expect(completions).toContain('args[0]');
+      expect(completions).toContain('args[1]');
+      expect(completions).toContain('args[2]'); // Next available
+    });
+
+    it('should show settable fields for unset', () => {
+      const [completions] = getConfigureCompletions('unset ', mode, dataProvider);
+
+      expect(completions).toContain('cwd');
+      expect(completions).toContain('args');
+      expect(completions).toContain('args[0]');
+      expect(completions).toContain('args[1]');
+      expect(completions).toContain('env.MY_VAR');
+    });
+  });
+
+  describe('case insensitivity', () => {
+    beforeEach(() => {
+      mode.enter();
+    });
+
+    it('should match commands case-insensitively', () => {
+      const [completions] = getConfigureCompletions('CON', mode, dataProvider);
+
+      expect(completions).toContain('connector');
+    });
+
+    it('should match connector IDs case-insensitively', () => {
+      const [completions] = getConfigureCompletions('connector MCP', mode, dataProvider);
+
+      expect(completions).toContain('mcp-server');
+    });
+  });
+
+  describe('quoted value handling', () => {
+    beforeEach(async () => {
+      mode.enter();
+      await mode.editConnector('test-connector');
+    });
+
+    it('should handle quoted values in tokenization', () => {
+      // After a quoted value, should still suggest --secret
+      const [completions] = getConfigureCompletions('set command "npx -y" ', mode, dataProvider);
+
+      expect(completions).toContain('--secret');
+    });
+  });
+});

--- a/src/shell/configure/completer.ts
+++ b/src/shell/configure/completer.ts
@@ -1,0 +1,429 @@
+/**
+ * Configure Mode TAB Completion
+ *
+ * Provides command, field path, and value completion for configure mode.
+ */
+
+import type { ConfigureMode } from './mode.js';
+import type { Connector, StdioTransport, HttpTransport, SseTransport } from '../../types/config.js';
+
+/**
+ * Data provider for configure mode completions
+ */
+export interface ConfigureDataProvider {
+  getConnectorIds: () => string[];
+}
+
+/**
+ * Configure mode commands by context
+ */
+const ROOT_COMMANDS = [
+  'connector',      // IOS-style shortcut: connector <id>
+  'edit',           // edit connector <id>
+  'ls',             // List all connectors
+  'exit',           // Exit configure mode
+  'help',
+];
+
+const EDIT_SESSION_COMMANDS = [
+  'set',            // set <path> <value>
+  'unset',          // unset <path>
+  'show',           // Show current connector
+  'commit',         // Save changes
+  'discard',        // Discard changes
+  'exit',           // Exit edit session
+  'help',
+];
+
+/**
+ * Field paths available for set/unset commands
+ */
+const FIELD_PATHS = [
+  'enabled',
+  'command',
+  'cwd',
+  'args',
+  'args[0]',
+  'args[1]',
+  'args[2]',
+  // env.* is dynamic, handled separately
+];
+
+/**
+ * Common environment variable names for suggestions
+ */
+const COMMON_ENV_VARS = [
+  'env.PATH',
+  'env.HOME',
+  'env.USER',
+  'env.NODE_ENV',
+  'env.DEBUG',
+  'env.API_KEY',
+  'env.OPENAI_API_KEY',
+  'env.ANTHROPIC_API_KEY',
+  'env.GITHUB_TOKEN',
+];
+
+/**
+ * Options for various commands
+ */
+const COMMAND_OPTIONS: Record<string, string[]> = {
+  'set': ['--secret'],
+  'show': ['--json', 'candidate-config', 'diff'],
+  'commit': ['--dry-run', '--no-reload'],
+  'ls': ['--detail'],
+};
+
+/**
+ * Parse input line into tokens (same logic as commands.ts)
+ */
+function tokenize(line: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let inQuote = false;
+  let quoteChar = '';
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (inQuote) {
+      if (char === quoteChar) {
+        inQuote = false;
+        if (current) {
+          parts.push(current);
+          current = '';
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"' || char === "'") {
+        inQuote = true;
+        quoteChar = char;
+      } else if (char === ' ' || char === '\t') {
+        if (current) {
+          parts.push(current);
+          current = '';
+        }
+      } else {
+        current += char;
+      }
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+/**
+ * Get completions for configure mode
+ */
+export function getConfigureCompletions(
+  line: string,
+  mode: ConfigureMode,
+  dataProvider: ConfigureDataProvider
+): [string[], string] {
+  const tokens = tokenize(line);
+  const isNewToken = line.endsWith(' ') || tokens.length === 0;
+  const currentToken = isNewToken ? '' : (tokens[tokens.length - 1] || '');
+  const completedTokens = isNewToken ? tokens : tokens.slice(0, -1);
+
+  // Get candidates based on context
+  const candidates = getCandidates(completedTokens, currentToken, mode, dataProvider);
+
+  // Filter by prefix
+  const matches = candidates.filter(c =>
+    c.toLowerCase().startsWith(currentToken.toLowerCase())
+  );
+
+  return [matches, currentToken];
+}
+
+/**
+ * Get candidate completions based on tokens and mode state
+ */
+function getCandidates(
+  completedTokens: string[],
+  currentToken: string,
+  mode: ConfigureMode,
+  dataProvider: ConfigureDataProvider
+): string[] {
+  const isEditing = mode.isEditing();
+
+  // No tokens yet - complete commands
+  if (completedTokens.length === 0) {
+    if (isEditing) {
+      return EDIT_SESSION_COMMANDS;
+    }
+    return ROOT_COMMANDS;
+  }
+
+  const firstToken = completedTokens[0].toLowerCase();
+
+  // Handle specific commands
+  switch (firstToken) {
+    case 'connector':
+      // connector <id>
+      if (completedTokens.length === 1) {
+        return dataProvider.getConnectorIds();
+      }
+      return [];
+
+    case 'edit':
+      // edit connector <id>
+      if (completedTokens.length === 1) {
+        return ['connector'];
+      }
+      if (completedTokens.length === 2 && completedTokens[1].toLowerCase() === 'connector') {
+        return dataProvider.getConnectorIds();
+      }
+      return [];
+
+    case 'set':
+      return getSetCompletions(completedTokens, currentToken, mode);
+
+    case 'unset':
+      return getUnsetCompletions(completedTokens, currentToken, mode);
+
+    case 'show':
+      return getShowCompletions(completedTokens);
+
+    case 'commit':
+      return getCommitCompletions(completedTokens);
+
+    case 'ls':
+      return getLsCompletions(completedTokens);
+
+    case 'help':
+      // help <command>
+      if (completedTokens.length === 1) {
+        return isEditing ? EDIT_SESSION_COMMANDS : ROOT_COMMANDS;
+      }
+      return [];
+
+    default:
+      return [];
+  }
+}
+
+/**
+ * Get completions for 'set' command
+ * set <path> <value> [--secret]
+ */
+function getSetCompletions(
+  completedTokens: string[],
+  currentToken: string,
+  mode: ConfigureMode
+): string[] {
+  // set <path>
+  if (completedTokens.length === 1) {
+    return getFieldPathCompletions(currentToken, mode);
+  }
+
+  const path = completedTokens[1];
+
+  // set <path> <value>
+  if (completedTokens.length === 2) {
+    return getValueCompletions(path, mode);
+  }
+
+  // set <path> <value> [--secret]
+  // Check if --secret was already used
+  if (!completedTokens.includes('--secret')) {
+    return ['--secret'];
+  }
+
+  return [];
+}
+
+/**
+ * Get completions for 'unset' command
+ * unset <path>
+ */
+function getUnsetCompletions(
+  completedTokens: string[],
+  currentToken: string,
+  mode: ConfigureMode
+): string[] {
+  // unset <path>
+  if (completedTokens.length === 1) {
+    // Only suggest fields that are currently set
+    return getSetFieldPaths(mode);
+  }
+
+  return [];
+}
+
+/**
+ * Get completions for 'show' command
+ */
+function getShowCompletions(completedTokens: string[]): string[] {
+  if (completedTokens.length === 1) {
+    return COMMAND_OPTIONS['show'] || [];
+  }
+  return [];
+}
+
+/**
+ * Get completions for 'commit' command
+ */
+function getCommitCompletions(completedTokens: string[]): string[] {
+  const usedOptions = completedTokens.slice(1);
+  const availableOptions = (COMMAND_OPTIONS['commit'] || [])
+    .filter(opt => !usedOptions.includes(opt));
+  return availableOptions;
+}
+
+/**
+ * Get completions for 'ls' command in configure mode
+ */
+function getLsCompletions(completedTokens: string[]): string[] {
+  if (completedTokens.length === 1) {
+    return COMMAND_OPTIONS['ls'] || [];
+  }
+  return [];
+}
+
+/**
+ * Get field path completions for set command
+ */
+function getFieldPathCompletions(currentToken: string, mode: ConfigureMode): string[] {
+  const candidates: string[] = [...FIELD_PATHS];
+
+  // Add common env vars
+  candidates.push(...COMMON_ENV_VARS);
+
+  // If editing, add current connector's env keys
+  const connector = mode.getCurrentConnector();
+  if (connector) {
+    const transport = connector.transport as StdioTransport;
+    if (transport.env) {
+      for (const key of Object.keys(transport.env)) {
+        const envPath = `env.${key}`;
+        if (!candidates.includes(envPath)) {
+          candidates.push(envPath);
+        }
+      }
+    }
+
+    // Add actual args indices
+    if (transport.args && transport.args.length > 0) {
+      for (let i = 0; i < transport.args.length; i++) {
+        const argsPath = `args[${i}]`;
+        if (!candidates.includes(argsPath)) {
+          candidates.push(argsPath);
+        }
+      }
+      // Suggest next index for adding
+      const nextPath = `args[${transport.args.length}]`;
+      if (!candidates.includes(nextPath)) {
+        candidates.push(nextPath);
+      }
+    }
+  }
+
+  // If typing "env.", show custom key option
+  if (currentToken.startsWith('env.')) {
+    const existingEnvPaths = candidates.filter(c => c.startsWith('env.'));
+    return existingEnvPaths;
+  }
+
+  return candidates;
+}
+
+/**
+ * Get value completions based on field path
+ */
+function getValueCompletions(path: string, mode: ConfigureMode): string[] {
+  const lowerPath = path.toLowerCase();
+
+  // enabled: true/false
+  if (lowerPath === 'enabled') {
+    return ['true', 'false'];
+  }
+
+  // command: suggest common commands
+  if (lowerPath === 'command') {
+    return [
+      'npx',
+      'uvx',
+      'node',
+      'python',
+      'python3',
+      'deno',
+      'bun',
+    ];
+  }
+
+  // cwd: suggest some common patterns
+  if (lowerPath === 'cwd') {
+    return [
+      '.',
+      '..',
+      '~',
+      '/tmp',
+    ];
+  }
+
+  // For env.* paths, suggest --secret if it looks like a secret key
+  if (lowerPath.startsWith('env.')) {
+    const key = path.slice(4).toUpperCase();
+    const secretPatterns = ['KEY', 'SECRET', 'TOKEN', 'PASSWORD', 'CREDENTIAL', 'AUTH'];
+    if (secretPatterns.some(p => key.includes(p))) {
+      return ['--secret']; // Hint to use --secret
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Get field paths that are currently set (for unset completion)
+ */
+function getSetFieldPaths(mode: ConfigureMode): string[] {
+  const connector = mode.getCurrentConnector();
+  if (!connector) {
+    return [];
+  }
+
+  const paths: string[] = [];
+  const transport = connector.transport as StdioTransport;
+
+  // Always-set fields that can't be unset
+  // enabled and command are required - don't suggest them for unset
+
+  // cwd is optional
+  if (transport.cwd) {
+    paths.push('cwd');
+  }
+
+  // args
+  if (transport.args && transport.args.length > 0) {
+    paths.push('args'); // Clear all args
+    for (let i = 0; i < transport.args.length; i++) {
+      paths.push(`args[${i}]`);
+    }
+  }
+
+  // env
+  if (transport.env) {
+    for (const key of Object.keys(transport.env)) {
+      paths.push(`env.${key}`);
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Create a readline-compatible completer function for configure mode
+ */
+export function createConfigureCompleter(
+  mode: ConfigureMode,
+  dataProvider: ConfigureDataProvider
+): (line: string) => [string[], string] {
+  return (line: string) => getConfigureCompletions(line, mode, dataProvider);
+}

--- a/src/shell/configure/index.ts
+++ b/src/shell/configure/index.ts
@@ -8,6 +8,11 @@ export { ConfigureMode } from './mode.js';
 export { EditSessionManager } from './session.js';
 export { processConfigureCommand, type CommandResult } from './commands.js';
 export {
+  getConfigureCompletions,
+  createConfigureCompleter,
+  type ConfigureDataProvider,
+} from './completer.js';
+export {
   type CommitResult,
   type EditSession,
   type ConfigureModeState,


### PR DESCRIPTION
## Summary
Add TAB completion support for configure mode (`conf t`), improving UX when editing connector configurations.

## Changes

### New File: `src/shell/configure/completer.ts`
- **Command completion**: `set`, `unset`, `show`, `commit`, `discard`, `exit`, etc.
- **Field path completion**: `enabled`, `command`, `cwd`, `args`, `args[N]`, `env.*`
- **Value suggestions**:
  - `enabled`: `true`/`false`
  - `command`: common commands (`npx`, `uvx`, `node`, `python`, etc.)
  - `env.*`: hints for `--secret` when key looks like a secret
- **Dynamic suggestions**: based on current connector state (existing env vars, args indices)
- **Context-aware**: different commands at root level vs edit session

### Updated: `src/shell/repl.ts`
- Switch to configure-specific completer when entering configure mode
- Switch back to normal shell completer when exiting
- Add `getConfigureDataProvider()` for connector ID completion in configure mode

### Tests: `src/shell/configure/completer.test.ts`
- 27 comprehensive test cases covering all completion scenarios

## Demo
```
proofscan(config)# con<TAB>
connector

proofscan(config)# connector <TAB>
mcp-server  my-connector  test-conn

proofscan(config-conn:test)# set <TAB>
enabled  command  cwd  args  args[0]  env.API_KEY  ...

proofscan(config-conn:test)# set enabled <TAB>
true  false

proofscan(config-conn:test)# commit <TAB>
--dry-run  --no-reload
```

## Testing
```bash
npm test -- --run src/shell/configure/
# 76 tests pass (including 27 new completer tests)
```