### PR TITLE
fix(shell): close readline before recreating to prevent duplicate input

### DIFF
--- a/src/shell/repl.ts
+++ b/src/shell/repl.ts
@@ -919,6 +919,12 @@ Tips:
    * Reset readline interface (recreate after pager or other stdin-consuming operations)
    */
   private resetReadline(): void {
+    // Close existing readline interface to prevent duplicate input
+    if (this.rl) {
+      this.rl.removeAllListeners();
+      this.rl.close();
+    }
+
     // Choose completer based on mode
     const completer = this.configureMode?.isActive()
       ? createConfigureCompleter(this.configureMode, this.getConfigureDataProvider())


### PR DESCRIPTION
## Problem

When entering/exiting configure mode in shell, input characters were being duplicated (2 characters appearing for each keystroke).

## Cause

`resetReadline()` was creating a new readline interface without closing the old one. Both interfaces were listening to stdin simultaneously, causing each keystroke to be processed twice.

## Fix

Close existing readline interface and remove all listeners before creating a new one.

```typescript
if (this.rl) {
  this.rl.removeAllListeners();
  this.rl.close();
}
```

## Testing

- Enter shell mode: `psh`
- Enter configure mode: `configure`
- Type normally - characters should not duplicate
- Exit configure mode: `exit`
- Type normally - characters should not duplicate