### PR TITLE
feat(a2a): add sessions/events normalization (Phase 6)

### DIFF
--- a/src/a2a/__tests__/normalizer.test.ts
+++ b/src/a2a/__tests__/normalizer.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeMcpEvent, normalizeA2aEvent } from '../normalizer.js';
+
+describe('normalizeMcpEvent', () => {
+  it('should normalize tools/call request', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'get_weather',
+        arguments: { city: 'Tokyo' },
+      },
+    };
+
+    const result = normalizeMcpEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('tool_call');
+    expect(result?.protocol).toBe('mcp');
+    expect(result?.content).toEqual({
+      type: 'tool_call',
+      name: 'get_weather',
+      arguments: { city: 'Tokyo' },
+    });
+  });
+
+  it('should normalize tools/call response', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        content: [{ type: 'text', text: 'Sunny, 25°C' }],
+        isError: false,
+      },
+    };
+
+    const result = normalizeMcpEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('tool_result');
+    expect(result?.protocol).toBe('mcp');
+    expect(result?.content).toMatchObject({
+      type: 'tool_result',
+      name: 'tool',
+      isError: false,
+    });
+  });
+
+  it('should normalize tools/call response with error', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        content: [{ type: 'text', text: 'Tool failed' }],
+        isError: true,
+      },
+    };
+
+    const result = normalizeMcpEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('tool_result');
+    expect(result?.content).toMatchObject({
+      type: 'tool_result',
+      isError: true,
+    });
+  });
+
+  it('should return null for unrecognized MCP events', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'unknown/method',
+    };
+
+    const result = normalizeMcpEvent(raw);
+
+    expect(result).toBeNull();
+  });
+
+  it('should handle missing params gracefully', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+    };
+
+    const result = normalizeMcpEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.content).toEqual({
+      type: 'tool_call',
+      name: 'unknown',
+      arguments: {},
+    });
+  });
+
+  it('should return null for non-object input', () => {
+    expect(normalizeMcpEvent(null)).toBeNull();
+    expect(normalizeMcpEvent(undefined)).toBeNull();
+    expect(normalizeMcpEvent('string')).toBeNull();
+    expect(normalizeMcpEvent(123)).toBeNull();
+  });
+});
+
+describe('normalizeA2aEvent', () => {
+  it('should normalize status event', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        taskId: 'task-123',
+        status: 'working',
+        message: {
+          role: 'assistant',
+          parts: [{ text: 'Processing...' }],
+        },
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('status');
+    expect(result?.protocol).toBe('a2a');
+    expect(result?.content).toEqual({
+      type: 'status',
+      status: 'working',
+      message: 'Processing...',
+    });
+  });
+
+  it('should normalize message event with assistant role', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        role: 'assistant',
+        parts: [{ text: 'Hello!' }],
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('message');
+    expect(result?.protocol).toBe('a2a');
+    expect(result?.actor).toBe('assistant');
+    expect(result?.content).toEqual({
+      type: 'text',
+      text: 'Hello!',
+    });
+  });
+
+  it('should normalize message event with user role', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        role: 'user',
+        parts: [{ text: 'Help me' }],
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('message');
+    expect(result?.actor).toBe('user');
+    expect(result?.content).toEqual({
+      type: 'text',
+      text: 'Help me',
+    });
+  });
+
+  it('should normalize artifact event', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        taskId: 'task-123',
+        artifact: {
+          name: 'report.pdf',
+          parts: [{ data: 'base64...', mimeType: 'application/pdf' }],
+        },
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('artifact');
+    expect(result?.protocol).toBe('a2a');
+    expect(result?.content).toMatchObject({
+      type: 'artifact',
+      name: 'report.pdf',
+      mimeType: 'application/pdf',
+      data: 'base64...',
+    });
+  });
+
+  it('should handle message with multiple text parts', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        role: 'assistant',
+        parts: [
+          { text: 'Hello ' },
+          { text: 'World!' },
+        ],
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('message');
+    expect(result?.content).toEqual({
+      type: 'text',
+      text: 'Hello World!',
+    });
+  });
+
+  it('should handle message with non-text parts', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        role: 'assistant',
+        parts: [
+          { data: 'base64...', mimeType: 'image/png' },
+          { text: 'Here is the image' },
+        ],
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('message');
+    expect(result?.content).toEqual({
+      type: 'text',
+      text: 'Here is the image',
+    });
+  });
+
+  it('should handle missing message', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        taskId: 'task-123',
+        status: 'working',
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('status');
+    expect(result?.content).toEqual({
+      type: 'status',
+      status: 'working',
+      message: '',
+    });
+  });
+
+  it('should handle artifact without name or mimeType', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        taskId: 'task-123',
+        artifact: {
+          parts: [{ data: 'some-data' }],
+        },
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('artifact');
+    expect(result?.content).toMatchObject({
+      type: 'artifact',
+      name: undefined,
+      mimeType: undefined,
+      data: 'some-data',
+    });
+  });
+
+  it('should return null for unrecognized A2A events', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+      result: {
+        unknownField: 'value',
+      },
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for non-object input', () => {
+    expect(normalizeA2aEvent(null)).toBeNull();
+    expect(normalizeA2aEvent(undefined)).toBeNull();
+    expect(normalizeA2aEvent('string')).toBeNull();
+    expect(normalizeA2aEvent(123)).toBeNull();
+  });
+
+  it('should return null when result is missing', () => {
+    const raw = {
+      jsonrpc: '2.0',
+      id: 'req-1',
+    };
+
+    const result = normalizeA2aEvent(raw);
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/a2a/index.ts
+++ b/src/a2a/index.ts
@@ -8,3 +8,4 @@ export * from './types.js';
 export * from './config.js';
 export * from './agent-card.js';
 export * from './client.js';
+export * from './normalizer.js';

--- a/src/a2a/normalizer.ts
+++ b/src/a2a/normalizer.ts
@@ -1,0 +1,187 @@
+/**
+ * A2A/MCP Event Normalizer
+ *
+ * Converts protocol-specific event formats to a normalized, protocol-agnostic format.
+ * Used for unified analysis and reporting across MCP and A2A protocols.
+ */
+
+// ===== Normalized Event Types =====
+
+/**
+ * Protocol-agnostic normalized event format
+ * Stored in events.normalized_json
+ */
+export interface NormalizedEvent {
+  /** Event version for future schema evolution */
+  version: 1;
+
+  /** Source protocol */
+  protocol: 'mcp' | 'a2a';
+
+  /** Event type */
+  type: 'message' | 'tool_call' | 'tool_result' | 'status' | 'artifact' | 'error';
+
+  /** Timestamp (ISO8601) */
+  timestamp: string;
+
+  /** Actor (user/assistant/system) */
+  actor: 'user' | 'assistant' | 'system';
+
+  /** Content (type-specific) */
+  content: NormalizedContent;
+
+  /** Optional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+type NormalizedContent =
+  | { type: 'text'; text: string }
+  | { type: 'tool_call'; name: string; arguments: Record<string, unknown> }
+  | { type: 'tool_result'; name: string; result: unknown; isError?: boolean }
+  | { type: 'status'; status: string; message?: string }
+  | { type: 'artifact'; name?: string; mimeType?: string; data?: string }
+  | { type: 'error'; code: number; message: string };
+
+// ===== Normalizer Functions =====
+
+/**
+ * Normalize MCP event to common format
+ */
+export function normalizeMcpEvent(raw: unknown): NormalizedEvent | null {
+  if (!raw || typeof raw !== 'object') return null;
+
+  const obj = raw as Record<string, unknown>;
+  const method = obj.method as string | undefined;
+
+  // tools/call request
+  if (method === 'tools/call') {
+    const params = obj.params as Record<string, unknown> | undefined;
+    return {
+      version: 1,
+      protocol: 'mcp',
+      type: 'tool_call',
+      timestamp: new Date().toISOString(),
+      actor: 'assistant',
+      content: {
+        type: 'tool_call',
+        name: params?.name as string || 'unknown',
+        arguments: params?.arguments as Record<string, unknown> || {},
+      },
+    };
+  }
+
+  // tools/call response
+  if (obj.result && typeof obj.id !== 'undefined') {
+    const result = obj.result as Record<string, unknown>;
+    if (result.content || result.isError !== undefined) {
+      return {
+        version: 1,
+        protocol: 'mcp',
+        type: 'tool_result',
+        timestamp: new Date().toISOString(),
+        actor: 'system',
+        content: {
+          type: 'tool_result',
+          name: 'tool', // Name not available in response
+          result: result.content,
+          isError: result.isError as boolean | undefined,
+        },
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Normalize A2A event to common format
+ */
+export function normalizeA2aEvent(raw: unknown): NormalizedEvent | null {
+  if (!raw || typeof raw !== 'object') return null;
+
+  const obj = raw as Record<string, unknown>;
+  const result = obj.result as Record<string, unknown> | undefined;
+  if (!result) return null;
+
+  // Status event
+  if ('status' in result && 'taskId' in result) {
+    return {
+      version: 1,
+      protocol: 'a2a',
+      type: 'status',
+      timestamp: new Date().toISOString(),
+      actor: 'system',
+      content: {
+        type: 'status',
+        status: result.status as string,
+        message: extractMessageText(result.message),
+      },
+    };
+  }
+
+  // Artifact event
+  if ('artifact' in result) {
+    const artifact = result.artifact as Record<string, unknown>;
+    return {
+      version: 1,
+      protocol: 'a2a',
+      type: 'artifact',
+      timestamp: new Date().toISOString(),
+      actor: 'assistant',
+      content: {
+        type: 'artifact',
+        name: artifact.name as string | undefined,
+        mimeType: extractMimeType(artifact.parts),
+        data: extractData(artifact.parts),
+      },
+    };
+  }
+
+  // Message event
+  if ('role' in result && 'parts' in result) {
+    return {
+      version: 1,
+      protocol: 'a2a',
+      type: 'message',
+      timestamp: new Date().toISOString(),
+      actor: result.role === 'assistant' ? 'assistant' : 'user',
+      content: {
+        type: 'text',
+        text: extractMessageText(result),
+      },
+    };
+  }
+
+  return null;
+}
+
+function extractMessageText(msg: unknown): string {
+  if (!msg || typeof msg !== 'object') return '';
+  const m = msg as Record<string, unknown>;
+  const parts = m.parts as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(parts)) return '';
+  return parts
+    .filter(p => 'text' in p)
+    .map(p => p.text as string)
+    .join('');
+}
+
+function extractMimeType(parts: unknown): string | undefined {
+  if (!Array.isArray(parts)) return undefined;
+  for (const part of parts) {
+    if (part && typeof part === 'object' && 'mimeType' in part) {
+      return part.mimeType as string;
+    }
+  }
+  return undefined;
+}
+
+function extractData(parts: unknown): string | undefined {
+  if (!Array.isArray(parts)) return undefined;
+  for (const part of parts) {
+    if (part && typeof part === 'object' && 'data' in part) {
+      return part.data as string;
+    }
+  }
+  return undefined;
+}

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -5,7 +5,7 @@
 import Database from 'better-sqlite3';
 import { join } from 'path';
 import { mkdirSync, statSync } from 'fs';
-import { EVENTS_DB_SCHEMA, PROOFS_DB_SCHEMA, EVENTS_DB_VERSION, PROOFS_DB_VERSION, EVENTS_DB_MIGRATION_1_TO_2, EVENTS_DB_MIGRATION_2_TO_3, EVENTS_DB_MIGRATION_3_TO_4, EVENTS_DB_MIGRATION_4_TO_5, EVENTS_DB_MIGRATION_5_TO_6, PROOFS_DB_MIGRATION_1_TO_2 } from './schema.js';
+import { EVENTS_DB_SCHEMA, PROOFS_DB_SCHEMA, EVENTS_DB_VERSION, PROOFS_DB_VERSION, EVENTS_DB_MIGRATION_1_TO_2, EVENTS_DB_MIGRATION_2_TO_3, EVENTS_DB_MIGRATION_3_TO_4, EVENTS_DB_MIGRATION_4_TO_5, EVENTS_DB_MIGRATION_5_TO_6, EVENTS_DB_MIGRATION_5_TO_6_DATA, PROOFS_DB_MIGRATION_1_TO_2 } from './schema.js';
 import { getDefaultConfigDir } from '../utils/config-path.js';
 
 let eventsDb: Database.Database | null = null;
@@ -286,6 +286,9 @@ function runEventsMigrations(db: Database.Database, fromVersion: number): void {
           }
         }
       }
+
+      // Run data migration: set target_id = connector_id for existing sessions
+      db.exec(EVENTS_DB_MIGRATION_5_TO_6_DATA);
 
       db.exec('COMMIT');
     } catch (err) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -249,6 +249,17 @@ ALTER TABLE sessions ADD COLUMN target_id TEXT;
 ALTER TABLE events ADD COLUMN normalized_json TEXT;
 `;
 
+/**
+ * Data migration from version 5 to version 6
+ * Migrate existing sessions: set target_id = connector_id
+ */
+export const EVENTS_DB_MIGRATION_5_TO_6_DATA = `
+-- Migrate existing sessions: set target_id = connector_id
+UPDATE sessions
+SET target_id = connector_id
+WHERE target_id IS NULL;
+`;
+
 // proofs.db schema (version 2: added plans and runs tables)
 export const PROOFS_DB_SCHEMA = `
 -- Proofs table (immutable, never pruned)

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -12,10 +12,11 @@ export type ActorKind = 'human' | 'agent' | 'system';
 export type EventDirection = 'client_to_server' | 'server_to_client';
 export type EventKind = 'request' | 'response' | 'notification' | 'transport_event';
 
-// Sessions table (Phase 3.4: added actor_*, secret_ref_count)
+// Sessions table (Phase 3.4: added actor_*, secret_ref_count; Phase 6: added target_id)
 export interface Session {
   session_id: string;
   connector_id: string;
+  target_id: string | null; // Phase 6: Unified connector/agent target ID
   started_at: string; // ISO8601
   ended_at: string | null;
   exit_reason: ExitReason | null;
@@ -49,7 +50,7 @@ export interface RpcCall {
   error_code: number | null;
 }
 
-// Events table (schema version 2)
+// Events table (schema version 2; Phase 6: added normalized_json)
 export interface Event {
   event_id: string;
   session_id: string;
@@ -61,6 +62,7 @@ export interface Event {
   summary: string | null;     // Phase 2.1: human-readable summary
   payload_hash: string | null; // Phase 2.1: SHA-256 first 16 chars
   raw_json: string | null;
+  normalized_json: string | null; // Phase 6: Protocol-agnostic normalized format
 }
 
 // Proofs table (proofs.db)


### PR DESCRIPTION
## Summary

Phase 6 of A2A integration: Data migration and event normalization.

## Changes

### Normalizer (`src/a2a/normalizer.ts`) - NEW
- `NormalizedEvent` interface - protocol-agnostic event format
- `normalizeMcpEvent()` - normalize MCP events (tools/call, responses)
- `normalizeA2aEvent()` - normalize A2A events (status, artifact, message)
- Helper functions for extracting text, mimeType, data from parts

### DB Types (`src/db/types.ts`)
- Added `target_id: string | null` to Session interface
- Added `normalized_json: string | null` to Event interface

### Schema (`src/db/schema.ts`)
- Added `EVENTS_DB_MIGRATION_5_TO_6_DATA` for data migration
- Migrates existing sessions: `target_id = connector_id WHERE target_id IS NULL`

### Connection (`src/db/connection.ts`)
- Execute data migration after schema migration (v5 → v6)

### Events Store (`src/db/events-store.ts`)
- `createSession()`: Auto-populate `target_id` from `connectorId`
- `logEvent()`: Accept optional `protocol` param, store `normalized_json`

### Tests (`src/a2a/__tests__/normalizer.test.ts`) - NEW
- 17 comprehensive tests covering:
  - MCP tools/call request normalization
  - MCP tools/call response normalization
  - A2A status event normalization
  - A2A message event normalization
  - A2A artifact event normalization
  - Edge cases (null input, invalid objects, missing fields)

## Scope Note

This phase focuses on data layer changes. Full `connector_id` → `target_id` refactor across CLI/API (57 files, 270 references) is planned for Phase 7.

## Testing

```bash
npm test  # 1662/1662 tests pass (+17 new)
```

## Related

- Phase 5: #77 (Streaming)
- Design: `vault/03_Projects/proofscan/A2A-phase6-normalization-design.md`
- Migration Notes: `vault/03_Projects/proofscan/A2A-migration-notes.md`