### PR TITLE
refactor: remove COALESCE patterns, use target_id directly (Phase 8)

### DIFF
--- a/src/db/proofs-store.ts
+++ b/src/db/proofs-store.ts
@@ -95,7 +95,7 @@ export class ProofsStore {
    * Get proofs by target
    */
   getProofsByTarget(targetId: string, limit?: number): Proof[] {
-    let sql = `SELECT * FROM proofs WHERE COALESCE(target_id, connector_id) = ? ORDER BY created_at DESC`;
+    let sql = `SELECT * FROM proofs WHERE target_id = ? ORDER BY created_at DESC`;
     if (limit) {
       sql += ` LIMIT ${limit}`;
     }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -309,7 +309,7 @@ CREATE TABLE IF NOT EXISTS proofs (
   created_at TEXT NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_proofs_target ON proofs(COALESCE(target_id, connector_id));
+CREATE INDEX IF NOT EXISTS idx_proofs_target ON proofs(target_id);
 CREATE INDEX IF NOT EXISTS idx_proofs_connector ON proofs(connector_id);
 CREATE INDEX IF NOT EXISTS idx_proofs_session ON proofs(session_id);
 CREATE INDEX IF NOT EXISTS idx_proofs_created ON proofs(created_at);

--- a/src/shell/ref-resolver.test.ts
+++ b/src/shell/ref-resolver.test.ts
@@ -178,7 +178,6 @@ describe('RefResolver', () => {
 
       vi.mocked(mockDataProvider.getLatestSession).mockReturnValue({
         session_id: 'session-789',
-        connector_id: 'mcp-server',
         target_id: 'mcp-server',
       });
 
@@ -251,7 +250,6 @@ describe('RefResolver', () => {
 
       vi.mocked(mockDataProvider.getSessionByPrefix).mockReturnValue({
         session_id: 'session-full-id',
-        connector_id: 'mcp-server',
         target_id: 'mcp-server',
       });
 
@@ -392,7 +390,6 @@ describe('RefResolver', () => {
 
       vi.mocked(mockDataProvider.getSessionByPrefix).mockReturnValue({
         session_id: 'session-full',
-        connector_id: 'mcp-server',
         target_id: 'mcp-server',
       });
 

--- a/src/shell/ref-resolver.ts
+++ b/src/shell/ref-resolver.ts
@@ -84,13 +84,13 @@ export interface ResolveResult {
  */
 export interface RefDataProvider {
   /** Get latest session for a target (or globally if no target) */
-  getLatestSession(targetId?: string): { session_id: string; connector_id: string } | null;
+  getLatestSession(targetId?: string): { session_id: string; target_id: string } | null;
   /** Get latest RPC for a session */
   getLatestRpc(sessionId: string): { rpc_id: string; method: string } | null;
   /** Get RPC by ID */
   getRpcById(rpcId: string, sessionId?: string): { rpc_id: string; session_id: string; method: string } | null;
   /** Get session by ID or prefix */
-  getSessionByPrefix(prefix: string, connectorId?: string): { session_id: string; connector_id: string } | null;
+  getSessionByPrefix(prefix: string, targetId?: string): { session_id: string; target_id: string } | null;
   /** Get user-defined ref by name */
   getUserRef(name: string): RefStruct | null;
   /** Get favorite by name */
@@ -271,7 +271,7 @@ export class RefResolver {
         success: true,
         ref: {
           kind: 'session',
-          target: latestSession.connector_id,
+          target: latestSession.target_id,
           session: latestSession.session_id,
           level: 'connector',
           captured_at: new Date().toISOString(),
@@ -336,7 +336,7 @@ export class RefResolver {
       success: true,
       ref: {
         kind: 'session',
-        target: session.connector_id,
+        target: session.target_id,
         session: session.session_id,
         captured_at: new Date().toISOString(),
         source: `@session:${sessionId}`,
@@ -722,10 +722,10 @@ export function refFromJson(json: string): RefStruct | null {
  * This adapts the EventsStore to the RefDataProvider interface
  */
 export function createRefDataProvider(eventsStore: {
-  getLatestSession(targetId?: string): { session_id: string; connector_id: string } | null;
+  getLatestSession(targetId?: string): { session_id: string; target_id: string } | null;
   getLatestRpc(sessionId: string): { rpc_id: string; method: string } | null;
   getRpcById(rpcId: string, sessionId?: string): { rpc_id: string; session_id: string; method: string } | null;
-  getSessionByPrefix(prefix: string, connectorId?: string): { session_id: string; connector_id: string } | null;
+  getSessionByPrefix(prefix: string, targetId?: string): { session_id: string; target_id: string } | null;
   getUserRef(name: string): { kind: RefKind; target: string | null; session: string | null; rpc: string | null; proto: string | null; level: string | null; captured_at: string; entry_id?: string | null; target_path?: string | null } | null;
 }): RefDataProvider {
   return {


### PR DESCRIPTION
## Summary

Phase 8 of the connector_id → target_id migration. Removes all COALESCE patterns and uses target_id directly.

## Changes

- Remove `COALESCE(target_id, connector_id)` patterns (10 occurrences)
- Update return types to use `target_id` instead of `connector_id`
- Simplify proofs index to `target_id` only
- All queries now use `target_id` directly

## Files Changed (6)
- `src/db/events-store.ts`
- `src/db/proofs-store.ts`
- `src/db/tool-analysis.ts`
- `src/db/schema.ts`
- Related test files

## Testing

- ✅ `npm run build` passes
- ✅ All 1662 tests pass

## Related

- Follows PR #79 (Phase 7: connector_id → target_id migration)