### PR TITLE
feat(Phase 2.4.1): history --task with summary and timeline views

### DIFF
--- a/src/shell/completer.ts
+++ b/src/shell/completer.ts
@@ -184,9 +184,14 @@ function getRouterCompletions(
       if (tokens.length > 0 && tokens[tokens.length - 1] === '--role') {
         return ['user', 'assistant'];
       }
+      // --task completion (Phase 2.4.1)
+      if (tokens.length > 0 && tokens[tokens.length - 1] === '--task') {
+        // Could add taskId suggestions from DB here in future
+        return [];
+      }
       // Options completion
       if (tokens.length === 1) {
-        return ['-n', '-s', '--search', '--role', '-h', '--help'];
+        return ['-n', '-s', '--search', '--role', '--task', '-h', '--help'];
       }
       return [];
 


### PR DESCRIPTION
## Summary
Add `history --task` for viewing Task events.

## Commands

### `history --task` (no args) - Task Summary
Shows recent tasks with one row per task:
```
Task ID         Status        Events  Last Activity
────────────────────────────────────────────────────
abc123...       completed     3       2m ago
def456...       failed        2       5m ago
```

### `history --task <id>` - Task Timeline
Shows events for a specific task:
```
#     Time        Category        Status        Details
──────────────────────────────────────────────────────────
1     18:05:32    created         pending       
2     18:05:33    status          working       
3     18:05:35    terminal        completed     3 msgs
```

## Event Categories
| Category | Description |
|----------|-------------|
| `created` | Task creation |
| `status` | Status transitions (deduped) |
| `terminal` | completed/failed/canceled |
| `client_error` | timeout/poll_error |

## Deduplication
Consecutive `a2a:task:updated` events with same status are hidden to reduce noise.

## Tests
All 1778 tests pass.