### PR TITLE
feat(proofportal): Phase 4 - ProofPortal MVP

### DIFF
--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -4,7 +4,7 @@
  * Phase 8.2: Bearer Token Authentication
  * Phase 8.3: MCP Proxy
  * Phase 8.4: A2A Proxy
- * Phase 9.4: ProofPortal integration
+ * Phase 4: ProofPortal integration
  */
 
 import Fastify, { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
@@ -209,7 +209,7 @@ export function createGatewayServer(
 
     log.info({ event: 'proofcomm_routes_enabled', configDir });
 
-    // ProofPortal routes (Phase 9.4)
+    // ProofPortal routes (Phase 4)
     // Read-only SSE-based visualization UI
     registerPortalRoutes(server);
     log.info({ event: 'portal_routes_enabled', path: '/portal' });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -4,6 +4,7 @@
  * Phase 8.2: Bearer Token Authentication
  * Phase 8.3: MCP Proxy
  * Phase 8.4: A2A Proxy
+ * Phase 9.4: ProofPortal integration
  */
 
 import Fastify, { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
@@ -16,6 +17,7 @@ import { createA2AProxyHandler, A2AProxyRequest } from './a2aProxy.js';
 import { createAuditLogger, AuditLogger } from './audit.js';
 import { sseStreamHandler, getSseManager } from './sse.js';
 import { registerProofCommRoutes } from './proofcommProxy.js';
+import { registerPortalRoutes } from '../proofportal/index.js';
 
 export interface GatewayServer {
   /** Fastify instance */
@@ -206,6 +208,11 @@ export function createGatewayServer(
     });
 
     log.info({ event: 'proofcomm_routes_enabled', configDir });
+
+    // ProofPortal routes (Phase 9.4)
+    // Read-only SSE-based visualization UI
+    registerPortalRoutes(server);
+    log.info({ event: 'portal_routes_enabled', path: '/portal' });
   }
 
   // Graceful shutdown handlers

--- a/src/proofportal/__tests__/templates.test.ts
+++ b/src/proofportal/__tests__/templates.test.ts
@@ -8,7 +8,7 @@ import { renderDashboard } from '../templates/dashboard.js';
 import { escapeHtml, renderLayout } from '../templates/layout.js';
 import {
   createInitialState,
-  updateState,
+  applyEvent,
   toDisplayEvent,
   type PortalSseEvent,
 } from '../types.js';
@@ -152,9 +152,9 @@ describe('ProofPortal state management', () => {
     });
   });
 
-  describe('updateState', () => {
+  describe('applyEvent', () => {
     it('should update thread state', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -167,14 +167,14 @@ describe('ProofPortal state management', () => {
         },
       };
 
-      state = updateState(state, event);
+      applyEvent(state, event);
 
       expect(state.threads.size).toBe(1);
       expect(state.threads.get('trace-1')?.participants.has('agent-1')).toBe(true);
     });
 
     it('should update space state on join', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -187,17 +187,17 @@ describe('ProofPortal state management', () => {
         },
       };
 
-      state = updateState(state, event);
+      applyEvent(state, event);
 
       expect(state.spaces.size).toBe(1);
       expect(state.spaces.get('space-1')?.members.has('agent-1')).toBe(true);
     });
 
     it('should update space state on leave', () => {
-      let state = createInitialState();
+      const state = createInitialState();
 
       // First join
-      state = updateState(state, {
+      applyEvent(state, {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
         ts: 1704067200000,
@@ -210,7 +210,7 @@ describe('ProofPortal state management', () => {
       });
 
       // Then leave
-      state = updateState(state, {
+      applyEvent(state, {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
         ts: 1704067201000,
@@ -226,7 +226,7 @@ describe('ProofPortal state management', () => {
     });
 
     it('should increment message count', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -238,14 +238,14 @@ describe('ProofPortal state management', () => {
         },
       };
 
-      state = updateState(state, event);
-      state = updateState(state, { ...event, request_id: 'req-2' });
+      applyEvent(state, event);
+      applyEvent(state, { ...event, request_id: 'req-2' });
 
       expect(state.spaces.get('space-1')?.messageCount).toBe(2);
     });
 
     it('should update agent state', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -259,7 +259,7 @@ describe('ProofPortal state management', () => {
         },
       };
 
-      state = updateState(state, event);
+      applyEvent(state, event);
 
       expect(state.agents.size).toBe(1);
       const agent = state.agents.get('agent-1');
@@ -269,7 +269,7 @@ describe('ProofPortal state management', () => {
     });
 
     it('should increment global event count', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -278,11 +278,60 @@ describe('ProofPortal state management', () => {
         metadata: { action: 'message' },
       };
 
-      state = updateState(state, event);
-      state = updateState(state, { ...event, request_id: 'req-2' });
-      state = updateState(state, { ...event, request_id: 'req-3' });
+      applyEvent(state, event);
+      applyEvent(state, { ...event, request_id: 'req-2' });
+      applyEvent(state, { ...event, request_id: 'req-3' });
 
       expect(state.eventCount).toBe(3);
+    });
+  });
+});
+
+describe('ProofPortal routes', () => {
+  // Note: Full route testing requires Fastify server setup.
+  // These tests verify the route registration function exists and has correct exports.
+
+  describe('registerPortalRoutes', () => {
+    it('should be exported from index', async () => {
+      const { registerPortalRoutes } = await import('../index.js');
+      expect(typeof registerPortalRoutes).toBe('function');
+    });
+  });
+
+  describe('PortalRoutesOptions', () => {
+    it('should allow basePath option', async () => {
+      const { registerPortalRoutes } = await import('../routes.js');
+
+      // Mock Fastify instance
+      const routes: Array<{ method: string; path: string }> = [];
+      const mockFastify = {
+        get: (path: string, _handler: unknown) => {
+          routes.push({ method: 'GET', path });
+        },
+      };
+
+      registerPortalRoutes(mockFastify as never, { basePath: '/custom-portal' });
+
+      expect(routes).toContainEqual({ method: 'GET', path: '/custom-portal' });
+      expect(routes).toContainEqual({ method: 'GET', path: '/custom-portal/' });
+      expect(routes).toContainEqual({ method: 'GET', path: '/custom-portal/api/status' });
+    });
+
+    it('should use default basePath /portal', async () => {
+      const { registerPortalRoutes } = await import('../routes.js');
+
+      const routes: Array<{ method: string; path: string }> = [];
+      const mockFastify = {
+        get: (path: string, _handler: unknown) => {
+          routes.push({ method: 'GET', path });
+        },
+      };
+
+      registerPortalRoutes(mockFastify as never);
+
+      expect(routes).toContainEqual({ method: 'GET', path: '/portal' });
+      expect(routes).toContainEqual({ method: 'GET', path: '/portal/' });
+      expect(routes).toContainEqual({ method: 'GET', path: '/portal/api/status' });
     });
   });
 });

--- a/src/proofportal/__tests__/templates.test.ts
+++ b/src/proofportal/__tests__/templates.test.ts
@@ -1,0 +1,288 @@
+/**
+ * ProofPortal - Template tests
+ * Phase 4: ProofPortal MVP
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderDashboard } from '../templates/dashboard.js';
+import { escapeHtml, renderLayout } from '../templates/layout.js';
+import {
+  createInitialState,
+  updateState,
+  toDisplayEvent,
+  type PortalSseEvent,
+} from '../types.js';
+
+describe('ProofPortal templates', () => {
+  describe('escapeHtml', () => {
+    it('should escape HTML special characters', () => {
+      expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+        '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+      );
+    });
+
+    it('should escape ampersand', () => {
+      expect(escapeHtml('foo & bar')).toBe('foo &amp; bar');
+    });
+
+    it('should escape single quotes', () => {
+      expect(escapeHtml("it's")).toBe('it&#039;s');
+    });
+  });
+
+  describe('renderLayout', () => {
+    it('should render complete HTML document', () => {
+      const html = renderLayout({
+        title: 'Test Portal',
+        content: '<div>Test content</div>',
+      });
+
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('<title>Test Portal</title>');
+      expect(html).toContain('<div>Test content</div>');
+      expect(html).toContain('data-app="portal"');
+    });
+
+    it('should include connection status element', () => {
+      const html = renderLayout({
+        title: 'Test',
+        content: '',
+      });
+
+      expect(html).toContain('id="connectionStatus"');
+      expect(html).toContain('connection-status');
+    });
+
+    it('should include scripts when provided', () => {
+      const html = renderLayout({
+        title: 'Test',
+        content: '',
+        scripts: 'console.log("test");',
+      });
+
+      expect(html).toContain('console.log("test");');
+    });
+  });
+
+  describe('renderDashboard', () => {
+    it('should render dashboard with three panels', () => {
+      const html = renderDashboard({
+        generatedAt: '2024-01-01T00:00:00Z',
+      });
+
+      expect(html).toContain('id="agentList"');
+      expect(html).toContain('id="threadList"');
+      expect(html).toContain('id="spaceList"');
+    });
+
+    it('should include SSE client script', () => {
+      const html = renderDashboard({
+        generatedAt: '2024-01-01T00:00:00Z',
+      });
+
+      expect(html).toContain('EventSource');
+      expect(html).toContain('proofcomm_space');
+    });
+
+    it('should show generated timestamp', () => {
+      const html = renderDashboard({
+        generatedAt: '2024-01-01T00:00:00Z',
+      });
+
+      expect(html).toContain('2024-01-01T00:00:00Z');
+    });
+  });
+});
+
+describe('ProofPortal state management', () => {
+  describe('createInitialState', () => {
+    it('should create empty state', () => {
+      const state = createInitialState();
+
+      expect(state.threads.size).toBe(0);
+      expect(state.spaces.size).toBe(0);
+      expect(state.agents.size).toBe(0);
+      expect(state.connected).toBe(false);
+      expect(state.eventCount).toBe(0);
+    });
+  });
+
+  describe('toDisplayEvent', () => {
+    it('should convert SSE event to display format', () => {
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        trace_id: 'trace-1',
+        metadata: {
+          action: 'message',
+          space_id: 'space-1',
+          space_name: 'Test Space',
+          agent_id: 'agent-1',
+          message_preview: 'Hello world',
+        },
+      };
+
+      const display = toDisplayEvent(event);
+
+      expect(display.id).toBe('req-1');
+      expect(display.eventKind).toBe('proofcomm_space');
+      expect(display.action).toBe('message');
+      expect(display.traceId).toBe('trace-1');
+      expect(display.spaceId).toBe('space-1');
+      expect(display.spaceName).toBe('Test Space');
+      expect(display.agentId).toBe('agent-1');
+      expect(display.preview).toBe('Hello world');
+    });
+
+    it('should handle missing metadata', () => {
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+      };
+
+      const display = toDisplayEvent(event);
+
+      expect(display.traceId).toBeNull();
+      expect(display.spaceId).toBeNull();
+      expect(display.agentId).toBeNull();
+    });
+  });
+
+  describe('updateState', () => {
+    it('should update thread state', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        trace_id: 'trace-1',
+        metadata: {
+          action: 'message',
+          agent_id: 'agent-1',
+        },
+      };
+
+      state = updateState(state, event);
+
+      expect(state.threads.size).toBe(1);
+      expect(state.threads.get('trace-1')?.participants.has('agent-1')).toBe(true);
+    });
+
+    it('should update space state on join', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        metadata: {
+          action: 'joined',
+          space_id: 'space-1',
+          agent_id: 'agent-1',
+        },
+      };
+
+      state = updateState(state, event);
+
+      expect(state.spaces.size).toBe(1);
+      expect(state.spaces.get('space-1')?.members.has('agent-1')).toBe(true);
+    });
+
+    it('should update space state on leave', () => {
+      let state = createInitialState();
+
+      // First join
+      state = updateState(state, {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        metadata: {
+          action: 'joined',
+          space_id: 'space-1',
+          agent_id: 'agent-1',
+        },
+      });
+
+      // Then leave
+      state = updateState(state, {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067201000,
+        request_id: 'req-2',
+        metadata: {
+          action: 'left',
+          space_id: 'space-1',
+          agent_id: 'agent-1',
+        },
+      });
+
+      expect(state.spaces.get('space-1')?.members.has('agent-1')).toBe(false);
+    });
+
+    it('should increment message count', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        metadata: {
+          action: 'message',
+          space_id: 'space-1',
+        },
+      };
+
+      state = updateState(state, event);
+      state = updateState(state, { ...event, request_id: 'req-2' });
+
+      expect(state.spaces.get('space-1')?.messageCount).toBe(2);
+    });
+
+    it('should update agent state', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        trace_id: 'trace-1',
+        metadata: {
+          action: 'message',
+          space_id: 'space-1',
+          agent_id: 'agent-1',
+        },
+      };
+
+      state = updateState(state, event);
+
+      expect(state.agents.size).toBe(1);
+      const agent = state.agents.get('agent-1');
+      expect(agent?.eventCount).toBe(1);
+      expect(agent?.traceIds.has('trace-1')).toBe(true);
+      expect(agent?.spaceIds.has('space-1')).toBe(true);
+    });
+
+    it('should increment global event count', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        metadata: { action: 'message' },
+      };
+
+      state = updateState(state, event);
+      state = updateState(state, { ...event, request_id: 'req-2' });
+      state = updateState(state, { ...event, request_id: 'req-3' });
+
+      expect(state.eventCount).toBe(3);
+    });
+  });
+});

--- a/src/proofportal/index.ts
+++ b/src/proofportal/index.ts
@@ -1,0 +1,39 @@
+/**
+ * ProofPortal - Agent Communication Visualization
+ * Phase 4: ProofPortal MVP
+ *
+ * Real-time visualization UI for ProofComm agent communication.
+ * Consumes SSE events and provides read-only monitoring.
+ *
+ * Usage:
+ *   import { registerPortalRoutes } from './proofportal/index.js';
+ *   registerPortalRoutes(fastify);
+ *
+ * Access:
+ *   http://localhost:8080/portal
+ */
+
+// Route registration
+export { registerPortalRoutes, type PortalRoutesOptions } from './routes.js';
+
+// Types
+export {
+  type PortalState,
+  type ThreadState,
+  type SpaceState,
+  type AgentState,
+  type PortalEventDisplay,
+  type PortalSseEvent,
+  type ProofCommMetadata,
+  type ProofCommAction,
+  PROOFCOMM_EVENT_KINDS,
+  createInitialState,
+  toDisplayEvent,
+  updateState,
+} from './types.js';
+
+// Templates
+export { renderDashboard, renderLayout, escapeHtml } from './templates/index.js';
+
+// SSE Client script
+export { getSseClientScript } from './sse-client.js';

--- a/src/proofportal/index.ts
+++ b/src/proofportal/index.ts
@@ -29,7 +29,7 @@ export {
   PROOFCOMM_EVENT_KINDS,
   createInitialState,
   toDisplayEvent,
-  updateState,
+  applyEvent,
 } from './types.js';
 
 // Templates

--- a/src/proofportal/routes.ts
+++ b/src/proofportal/routes.ts
@@ -1,0 +1,58 @@
+/**
+ * ProofPortal - Fastify route registration
+ * Phase 4: ProofPortal MVP
+ *
+ * Registers portal routes on the Gateway Fastify server.
+ * Portal is read-only and consumes SSE events from /events/stream
+ */
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { renderDashboard } from './templates/index.js';
+
+/**
+ * Options for registering portal routes
+ */
+export interface PortalRoutesOptions {
+  /** Base path for portal routes (default: '/portal') */
+  basePath?: string;
+}
+
+/**
+ * Register ProofPortal routes on a Fastify instance
+ *
+ * Routes:
+ * - GET /portal - Main dashboard (HTML)
+ * - GET /portal/api/status - Portal status (JSON)
+ */
+export function registerPortalRoutes(
+  fastify: FastifyInstance,
+  options: PortalRoutesOptions = {}
+): void {
+  const basePath = options.basePath ?? '/portal';
+
+  // GET /portal - Main dashboard
+  fastify.get(basePath, async (_request: FastifyRequest, reply: FastifyReply) => {
+    const html = renderDashboard({
+      generatedAt: new Date().toISOString(),
+    });
+
+    return reply
+      .header('Content-Type', 'text/html; charset=utf-8')
+      .send(html);
+  });
+
+  // GET /portal/ - Also handle trailing slash
+  fastify.get(`${basePath}/`, async (_request: FastifyRequest, reply: FastifyReply) => {
+    return reply.redirect(basePath);
+  });
+
+  // GET /portal/api/status - Portal status (JSON)
+  fastify.get(`${basePath}/api/status`, async (_request: FastifyRequest, _reply: FastifyReply) => {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      version: '4.0.0',
+      mode: 'sse',
+    };
+  });
+}

--- a/src/proofportal/routes.ts
+++ b/src/proofportal/routes.ts
@@ -4,6 +4,11 @@
  *
  * Registers portal routes on the Gateway Fastify server.
  * Portal is read-only and consumes SSE events from /events/stream
+ *
+ * Authentication:
+ * - All portal routes require Bearer token authentication (via Gateway auth middleware)
+ * - No additional permission check is required as portal is read-only visualization
+ * - SSE events are already filtered by the /events/stream endpoint permissions
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
@@ -23,12 +28,24 @@ export interface PortalRoutesOptions {
  * Routes:
  * - GET /portal - Main dashboard (HTML)
  * - GET /portal/api/status - Portal status (JSON)
+ *
+ * Security:
+ * - Requires Bearer token authentication (handled by Gateway preHandler)
+ * - Cache-Control: no-store prevents caching of dynamic dashboard
+ * - Content-Security-Policy restricts script execution
  */
 export function registerPortalRoutes(
   fastify: FastifyInstance,
   options: PortalRoutesOptions = {}
 ): void {
   const basePath = options.basePath ?? '/portal';
+
+  // Security headers for portal routes
+  const securityHeaders = {
+    'Cache-Control': 'no-store',
+    // Allow inline scripts (required for SSE client) but restrict other sources
+    'Content-Security-Policy': "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'",
+  };
 
   // GET /portal - Main dashboard
   fastify.get(basePath, async (_request: FastifyRequest, reply: FastifyReply) => {
@@ -38,6 +55,7 @@ export function registerPortalRoutes(
 
     return reply
       .header('Content-Type', 'text/html; charset=utf-8')
+      .headers(securityHeaders)
       .send(html);
   });
 
@@ -47,12 +65,14 @@ export function registerPortalRoutes(
   });
 
   // GET /portal/api/status - Portal status (JSON)
-  fastify.get(`${basePath}/api/status`, async (_request: FastifyRequest, _reply: FastifyReply) => {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      version: '4.0.0',
-      mode: 'sse',
-    };
+  fastify.get(`${basePath}/api/status`, async (_request: FastifyRequest, reply: FastifyReply) => {
+    return reply
+      .header('Cache-Control', 'no-store')
+      .send({
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+        version: '4.0.0',
+        mode: 'sse',
+      });
   });
 }

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -4,10 +4,22 @@
  *
  * This module generates inline JavaScript for browser-side SSE consumption.
  * The generated code runs in the browser to receive real-time events from Gateway.
+ *
+ * Note: Utility functions (formatTime, formatRelativeTime, truncateId, etc.)
+ * are intentionally duplicated here from the server-side component files.
+ * This duplication is architecturally unavoidable because:
+ * - Server-side: TypeScript modules used for SSR
+ * - Browser-side: Inline JavaScript with no module system
+ * The functions must be kept in sync manually.
  */
 
 /**
  * Get browser-side SSE client script
+ *
+ * WARNING: The returned script is embedded directly in the HTML page.
+ * Only trusted, hardcoded content should be used. Never pass user-controlled
+ * data to this function as it would create an XSS vulnerability.
+ *
  * This is embedded as inline JavaScript in the HTML page.
  */
 export function getSseClientScript(): string {
@@ -23,6 +35,11 @@ export function getSseClientScript(): string {
     'proofcomm_route'
   ];
 
+  // State size limits (LRU eviction when exceeded)
+  const MAX_THREADS = 100;
+  const MAX_SPACES = 50;
+  const MAX_AGENTS = 100;
+
   // State
   const state = {
     threads: new Map(),
@@ -37,6 +54,24 @@ export function getSseClientScript(): string {
   let reconnectAttempts = 0;
   const MAX_RECONNECT_ATTEMPTS = 10;
   const RECONNECT_DELAY = 3000;
+
+  /**
+   * Evict oldest entries from a Map to maintain size limit (LRU)
+   * Entries are evicted based on lastActivityAt or lastSeenAt field
+   */
+  function evictOldest(map, maxSize, timeField) {
+    if (map.size <= maxSize) return;
+
+    // Convert to array and sort by time (oldest first)
+    const entries = Array.from(map.entries())
+      .sort((a, b) => (a[1][timeField] || 0) - (b[1][timeField] || 0));
+
+    // Remove oldest entries until we're under the limit
+    const toRemove = map.size - maxSize;
+    for (let i = 0; i < toRemove; i++) {
+      map.delete(entries[i][0]);
+    }
+  }
 
   // DOM elements
   const connectionStatus = document.getElementById('connectionStatus');
@@ -167,6 +202,11 @@ export function getSseClientScript(): string {
       thread.lastActivityAt = now;
       if (agentId) thread.participants.add(agentId);
     }
+
+    // LRU eviction to prevent unbounded memory growth
+    evictOldest(state.agents, MAX_AGENTS, 'lastSeenAt');
+    evictOldest(state.spaces, MAX_SPACES, 'lastActivityAt');
+    evictOldest(state.threads, MAX_THREADS, 'lastActivityAt');
 
     // Update UI
     renderAgentList();

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -1,0 +1,342 @@
+/**
+ * ProofPortal - SSE Client (Browser-side)
+ * Phase 4: ProofPortal MVP
+ *
+ * This module generates inline JavaScript for browser-side SSE consumption.
+ * The generated code runs in the browser to receive real-time events from Gateway.
+ */
+
+/**
+ * Get browser-side SSE client script
+ * This is embedded as inline JavaScript in the HTML page.
+ */
+export function getSseClientScript(): string {
+  return `
+(function() {
+  'use strict';
+
+  // ProofComm event kinds to filter
+  const PROOFCOMM_KINDS = [
+    'proofcomm_space',
+    'proofcomm_skill',
+    'proofcomm_document',
+    'proofcomm_route'
+  ];
+
+  // State
+  const state = {
+    threads: new Map(),
+    spaces: new Map(),
+    agents: new Map(),
+    connected: false,
+    eventCount: 0,
+    lastEventTs: 0
+  };
+
+  let eventSource = null;
+  let reconnectAttempts = 0;
+  const MAX_RECONNECT_ATTEMPTS = 10;
+  const RECONNECT_DELAY = 3000;
+
+  // DOM elements
+  const connectionStatus = document.getElementById('connectionStatus');
+  const connectionText = connectionStatus?.querySelector('.connection-text');
+  const eventCountEl = document.getElementById('eventCount');
+  const agentListEl = document.getElementById('agentList');
+  const threadListEl = document.getElementById('threadList');
+  const spaceListEl = document.getElementById('spaceList');
+
+  /**
+   * Update connection status display
+   */
+  function updateConnectionStatus(connected) {
+    state.connected = connected;
+    if (connectionStatus) {
+      connectionStatus.className = 'connection-status ' + (connected ? 'connected' : 'disconnected');
+    }
+    if (connectionText) {
+      connectionText.textContent = connected ? 'Connected' : 'Disconnected';
+    }
+  }
+
+  /**
+   * Update event count display
+   */
+  function updateEventCount() {
+    if (eventCountEl) {
+      eventCountEl.textContent = state.eventCount + ' events';
+    }
+  }
+
+  /**
+   * Format timestamp
+   */
+  function formatTime(ts) {
+    const date = new Date(ts);
+    return date.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false
+    });
+  }
+
+  /**
+   * Escape HTML
+   */
+  function escapeHtml(str) {
+    if (!str) return '';
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /**
+   * Process incoming SSE event
+   */
+  function processEvent(data) {
+    const metadata = data.metadata || {};
+    const agentId = metadata.agent_id || data.client_id;
+    const spaceId = metadata.space_id;
+    const traceId = data.trace_id;
+    const now = data.ts || Date.now();
+
+    state.eventCount++;
+    state.lastEventTs = now;
+
+    // Update agent state
+    if (agentId) {
+      let agent = state.agents.get(agentId);
+      if (!agent) {
+        agent = {
+          agentId: agentId,
+          traceIds: new Set(),
+          spaceIds: new Set(),
+          eventCount: 0,
+          lastSeenAt: now
+        };
+        state.agents.set(agentId, agent);
+      }
+      agent.eventCount++;
+      agent.lastSeenAt = now;
+      if (traceId) agent.traceIds.add(traceId);
+      if (spaceId) agent.spaceIds.add(spaceId);
+    }
+
+    // Update space state
+    if (spaceId) {
+      let space = state.spaces.get(spaceId);
+      if (!space) {
+        space = {
+          spaceId: spaceId,
+          spaceName: metadata.space_name,
+          members: new Set(),
+          messageCount: 0,
+          lastActivityAt: now
+        };
+        state.spaces.set(spaceId, space);
+      }
+      space.lastActivityAt = now;
+      if (metadata.space_name) space.spaceName = metadata.space_name;
+
+      if (metadata.action === 'joined' && agentId) {
+        space.members.add(agentId);
+      } else if (metadata.action === 'left' && agentId) {
+        space.members.delete(agentId);
+      } else if (metadata.action === 'message') {
+        space.messageCount++;
+      }
+    }
+
+    // Update thread state
+    if (traceId) {
+      let thread = state.threads.get(traceId);
+      if (!thread) {
+        thread = {
+          traceId: traceId,
+          participants: new Set(),
+          eventCount: 0,
+          startedAt: now,
+          lastActivityAt: now
+        };
+        state.threads.set(traceId, thread);
+      }
+      thread.eventCount++;
+      thread.lastActivityAt = now;
+      if (agentId) thread.participants.add(agentId);
+    }
+
+    // Update UI
+    renderAgentList();
+    renderSpaceList();
+    renderThreadList();
+    updateEventCount();
+  }
+
+  /**
+   * Render agent list
+   */
+  function renderAgentList() {
+    if (!agentListEl) return;
+
+    if (state.agents.size === 0) {
+      agentListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">👤</div>No agents yet</div>';
+      return;
+    }
+
+    const agents = Array.from(state.agents.values())
+      .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
+      .slice(0, 20);
+
+    agentListEl.innerHTML = agents.map(agent => {
+      return '<div class="list-item">' +
+        '<div class="list-item-title">' + escapeHtml(agent.agentId) + '</div>' +
+        '<div class="list-item-meta">' +
+          '<span>' + agent.eventCount + ' events</span>' +
+          '<span>' + agent.spaceIds.size + ' spaces</span>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+
+    // Update panel header count
+    const header = agentListEl.closest('.panel')?.querySelector('.panel-count');
+    if (header) header.textContent = state.agents.size;
+  }
+
+  /**
+   * Render space list
+   */
+  function renderSpaceList() {
+    if (!spaceListEl) return;
+
+    if (state.spaces.size === 0) {
+      spaceListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🏠</div>No spaces yet</div>';
+      return;
+    }
+
+    const spaces = Array.from(state.spaces.values())
+      .sort((a, b) => b.lastActivityAt - a.lastActivityAt)
+      .slice(0, 20);
+
+    spaceListEl.innerHTML = spaces.map(space => {
+      const name = space.spaceName || space.spaceId;
+      return '<div class="list-item">' +
+        '<div class="list-item-title">' + escapeHtml(name) + '</div>' +
+        '<div class="list-item-meta">' +
+          '<span>' + space.members.size + ' members</span>' +
+          '<span>' + space.messageCount + ' messages</span>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+
+    // Update panel header count
+    const header = spaceListEl.closest('.panel')?.querySelector('.panel-count');
+    if (header) header.textContent = state.spaces.size;
+  }
+
+  /**
+   * Render thread list
+   */
+  function renderThreadList() {
+    if (!threadListEl) return;
+
+    if (state.threads.size === 0) {
+      threadListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🧵</div>No threads yet</div>';
+      return;
+    }
+
+    const threads = Array.from(state.threads.values())
+      .sort((a, b) => b.lastActivityAt - a.lastActivityAt)
+      .slice(0, 50);
+
+    threadListEl.innerHTML = threads.map(thread => {
+      const shortId = thread.traceId.slice(0, 8) + '...';
+      return '<div class="list-item">' +
+        '<div class="list-item-title">' + escapeHtml(shortId) + '</div>' +
+        '<div class="list-item-meta">' +
+          '<span>' + thread.eventCount + ' events</span>' +
+          '<span>' + thread.participants.size + ' agents</span>' +
+          '<span>' + formatTime(thread.lastActivityAt) + '</span>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+
+    // Update panel header count
+    const header = threadListEl.closest('.panel')?.querySelector('.panel-count');
+    if (header) header.textContent = state.threads.size;
+  }
+
+  /**
+   * Connect to SSE stream
+   */
+  function connect() {
+    if (eventSource) {
+      eventSource.close();
+    }
+
+    const kinds = PROOFCOMM_KINDS.join(',');
+    const url = '/events/stream?kinds=' + encodeURIComponent(kinds);
+
+    console.log('[Portal] Connecting to SSE:', url);
+    eventSource = new EventSource(url);
+
+    eventSource.onopen = function() {
+      console.log('[Portal] SSE connected');
+      updateConnectionStatus(true);
+      reconnectAttempts = 0;
+    };
+
+    eventSource.onerror = function(e) {
+      console.error('[Portal] SSE error:', e);
+      updateConnectionStatus(false);
+
+      if (eventSource.readyState === EventSource.CLOSED) {
+        scheduleReconnect();
+      }
+    };
+
+    eventSource.addEventListener('gateway_event', function(e) {
+      try {
+        const data = JSON.parse(e.data);
+        if (PROOFCOMM_KINDS.includes(data.event_kind)) {
+          processEvent(data);
+        }
+      } catch (err) {
+        console.error('[Portal] Failed to parse event:', err);
+      }
+    });
+  }
+
+  /**
+   * Schedule reconnection
+   */
+  function scheduleReconnect() {
+    if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      console.error('[Portal] Max reconnect attempts reached');
+      return;
+    }
+
+    reconnectAttempts++;
+    const delay = RECONNECT_DELAY * Math.min(reconnectAttempts, 5);
+    console.log('[Portal] Reconnecting in', delay, 'ms (attempt', reconnectAttempts, ')');
+
+    setTimeout(connect, delay);
+  }
+
+  // Initialize
+  renderAgentList();
+  renderSpaceList();
+  renderThreadList();
+  connect();
+
+  // Cleanup on page unload
+  window.addEventListener('beforeunload', function() {
+    if (eventSource) {
+      eventSource.close();
+    }
+  });
+})();
+`;
+}

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -176,13 +176,48 @@ export function getSseClientScript(): string {
   }
 
   /**
+   * Get activity class based on last seen time
+   */
+  function getActivityClass(lastSeenAt) {
+    const now = Date.now();
+    const diffSec = (now - lastSeenAt) / 1000;
+    if (diffSec < 30) return 'active';
+    if (diffSec < 300) return 'recent';
+    return 'idle';
+  }
+
+  /**
+   * Format relative time (e.g., "2s ago", "5m ago")
+   */
+  function formatRelativeTime(ts) {
+    const now = Date.now();
+    const diffMs = now - ts;
+    const diffSec = Math.floor(diffMs / 1000);
+    if (diffSec < 60) return diffSec + 's ago';
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) return diffMin + 'm ago';
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return diffHour + 'h ago';
+    return Math.floor(diffHour / 24) + 'd ago';
+  }
+
+  /**
+   * Truncate ID for display
+   */
+  function truncateId(id, maxLen) {
+    if (!id) return '';
+    if (id.length <= maxLen) return id;
+    return id.slice(0, maxLen - 3) + '...';
+  }
+
+  /**
    * Render agent list
    */
   function renderAgentList() {
     if (!agentListEl) return;
 
     if (state.agents.size === 0) {
-      agentListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">👤</div>No agents yet</div>';
+      agentListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">👤</div><div class="empty-state-text">No agents yet</div><div class="empty-state-hint">Agents will appear when events are received</div></div>';
       return;
     }
 
@@ -190,13 +225,20 @@ export function getSseClientScript(): string {
       .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
       .slice(0, 20);
 
-    agentListEl.innerHTML = agents.map(agent => {
-      return '<div class="list-item">' +
-        '<div class="list-item-title">' + escapeHtml(agent.agentId) + '</div>' +
-        '<div class="list-item-meta">' +
-          '<span>' + agent.eventCount + ' events</span>' +
-          '<span>' + agent.spaceIds.size + ' spaces</span>' +
+    agentListEl.innerHTML = agents.map(function(agent) {
+      const activityClass = getActivityClass(agent.lastSeenAt);
+      const displayId = truncateId(agent.agentId, 20);
+      return '<div class="list-item agent-item ' + activityClass + '" data-agent-id="' + escapeHtml(agent.agentId) + '">' +
+        '<div class="agent-header">' +
+          '<span class="agent-indicator ' + activityClass + '"></span>' +
+          '<span class="agent-id" title="' + escapeHtml(agent.agentId) + '">' + escapeHtml(displayId) + '</span>' +
         '</div>' +
+        '<div class="agent-stats">' +
+          '<span class="stat-item" title="Events"><span class="stat-icon">📊</span><span class="stat-value">' + agent.eventCount + '</span></span>' +
+          '<span class="stat-item" title="Spaces"><span class="stat-icon">🏠</span><span class="stat-value">' + agent.spaceIds.size + '</span></span>' +
+          '<span class="stat-item" title="Threads"><span class="stat-icon">🧵</span><span class="stat-value">' + agent.traceIds.size + '</span></span>' +
+        '</div>' +
+        '<div class="agent-time">' + formatRelativeTime(agent.lastSeenAt) + '</div>' +
       '</div>';
     }).join('');
 
@@ -212,7 +254,7 @@ export function getSseClientScript(): string {
     if (!spaceListEl) return;
 
     if (state.spaces.size === 0) {
-      spaceListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🏠</div>No spaces yet</div>';
+      spaceListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🏠</div><div class="empty-state-text">No spaces yet</div><div class="empty-state-hint">Spaces appear when agents join or send messages</div></div>';
       return;
     }
 
@@ -220,13 +262,38 @@ export function getSseClientScript(): string {
       .sort((a, b) => b.lastActivityAt - a.lastActivityAt)
       .slice(0, 20);
 
-    spaceListEl.innerHTML = spaces.map(space => {
-      const name = space.spaceName || space.spaceId;
-      return '<div class="list-item">' +
-        '<div class="list-item-title">' + escapeHtml(name) + '</div>' +
-        '<div class="list-item-meta">' +
-          '<span>' + space.members.size + ' members</span>' +
-          '<span>' + space.messageCount + ' messages</span>' +
+    spaceListEl.innerHTML = spaces.map(function(space) {
+      const displayName = space.spaceName || truncateId(space.spaceId, 12);
+      const memberCount = space.members.size;
+      const isActive = space.messageCount > 0;
+
+      // Render up to 5 member badges
+      const memberArr = Array.from(space.members).slice(0, 5);
+      const memberBadges = memberArr.map(function(agentId) {
+        const initial = agentId.charAt(0).toUpperCase();
+        const shortId = agentId.slice(0, 8);
+        return '<div class="member-badge" title="' + escapeHtml(agentId) + '">' +
+          '<span class="member-avatar">' + initial + '</span>' +
+          '<span class="member-id">' + escapeHtml(shortId) + '</span>' +
+        '</div>';
+      }).join('');
+      const moreMembers = memberCount > 5 ? '<span class="more-members">+' + (memberCount - 5) + '</span>' : '';
+
+      return '<div class="space-card" data-space-id="' + escapeHtml(space.spaceId) + '">' +
+        '<div class="space-header">' +
+          '<div class="space-title">' +
+            '<span class="space-icon">🏠</span>' +
+            '<span class="space-name" title="' + escapeHtml(space.spaceId) + '">' + escapeHtml(displayName) + '</span>' +
+          '</div>' +
+        '</div>' +
+        '<div class="space-stats">' +
+          '<div class="space-stat"><span class="stat-label">Members</span><span class="stat-value">' + memberCount + '</span></div>' +
+          '<div class="space-stat"><span class="stat-label">Messages</span><span class="stat-value">' + space.messageCount + '</span></div>' +
+        '</div>' +
+        '<div class="space-members">' + memberBadges + moreMembers + '</div>' +
+        '<div class="space-activity">' +
+          '<span class="activity-indicator ' + (isActive ? 'active' : '') + '"></span>' +
+          '<span class="activity-text">' + (isActive ? 'Active' : 'Quiet') + '</span>' +
         '</div>' +
       '</div>';
     }).join('');
@@ -237,13 +304,24 @@ export function getSseClientScript(): string {
   }
 
   /**
+   * Format duration in human-readable format
+   */
+  function formatDuration(ms) {
+    if (ms < 1000) return ms + 'ms';
+    var sec = Math.floor(ms / 1000);
+    if (sec < 60) return sec + 's';
+    var min = Math.floor(sec / 60);
+    return min + 'm ' + (sec % 60) + 's';
+  }
+
+  /**
    * Render thread list
    */
   function renderThreadList() {
     if (!threadListEl) return;
 
     if (state.threads.size === 0) {
-      threadListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🧵</div>No threads yet</div>';
+      threadListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🧵</div><div class="empty-state-text">No threads yet</div><div class="empty-state-hint">Threads appear when traced events arrive</div></div>';
       return;
     }
 
@@ -251,14 +329,23 @@ export function getSseClientScript(): string {
       .sort((a, b) => b.lastActivityAt - a.lastActivityAt)
       .slice(0, 50);
 
-    threadListEl.innerHTML = threads.map(thread => {
-      const shortId = thread.traceId.slice(0, 8) + '...';
-      return '<div class="list-item">' +
-        '<div class="list-item-title">' + escapeHtml(shortId) + '</div>' +
-        '<div class="list-item-meta">' +
-          '<span>' + thread.eventCount + ' events</span>' +
-          '<span>' + thread.participants.size + ' agents</span>' +
-          '<span>' + formatTime(thread.lastActivityAt) + '</span>' +
+    threadListEl.innerHTML = threads.map(function(thread) {
+      const shortId = thread.traceId.slice(0, 8) + '…' + thread.traceId.slice(-4);
+      const participantCount = thread.participants.size;
+      const eventCount = thread.eventCount;
+      const duration = thread.lastActivityAt - thread.startedAt;
+
+      return '<div class="thread-card" data-trace-id="' + escapeHtml(thread.traceId) + '">' +
+        '<div class="thread-header">' +
+          '<span class="thread-id" title="' + escapeHtml(thread.traceId) + '">' + escapeHtml(shortId) + '</span>' +
+          '<span class="thread-meta">' +
+            '<span class="thread-stat">' + eventCount + ' events</span>' +
+            '<span class="thread-stat">' + participantCount + ' agents</span>' +
+          '</span>' +
+        '</div>' +
+        '<div class="thread-footer">' +
+          '<span class="thread-duration">' + formatDuration(duration) + '</span>' +
+          '<span class="thread-time">' + formatTime(thread.lastActivityAt) + '</span>' +
         '</div>' +
       '</div>';
     }).join('');

--- a/src/proofportal/templates/components/AgentList.ts
+++ b/src/proofportal/templates/components/AgentList.ts
@@ -1,0 +1,199 @@
+/**
+ * ProofPortal - AgentList Component
+ * Phase 4.3: Agent activity visualization
+ *
+ * Displays a list of active agents with:
+ * - Activity indicators (event count, last seen)
+ * - Space/thread participation counts
+ * - Click to filter events by agent
+ */
+
+import { escapeHtml } from '../layout.js';
+
+/**
+ * Agent display data
+ */
+export interface AgentDisplayData {
+  agentId: string;
+  eventCount: number;
+  spaceCount: number;
+  threadCount: number;
+  lastSeenAt: number;
+  isActive: boolean;  // activity in last 30 seconds
+}
+
+/**
+ * Format relative time (e.g., "2s ago", "5m ago")
+ */
+export function formatRelativeTime(ts: number): string {
+  const now = Date.now();
+  const diffMs = now - ts;
+  const diffSec = Math.floor(diffMs / 1000);
+
+  if (diffSec < 60) {
+    return `${diffSec}s ago`;
+  }
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) {
+    return `${diffMin}m ago`;
+  }
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) {
+    return `${diffHour}h ago`;
+  }
+  return `${Math.floor(diffHour / 24)}d ago`;
+}
+
+/**
+ * Truncate agent ID for display
+ */
+export function truncateAgentId(agentId: string, maxLen: number = 20): string {
+  if (agentId.length <= maxLen) {
+    return agentId;
+  }
+  return agentId.slice(0, maxLen - 3) + '...';
+}
+
+/**
+ * Get activity class based on last seen time
+ */
+export function getActivityClass(lastSeenAt: number): string {
+  const now = Date.now();
+  const diffSec = (now - lastSeenAt) / 1000;
+
+  if (diffSec < 30) return 'active';
+  if (diffSec < 300) return 'recent';
+  return 'idle';
+}
+
+/**
+ * Render a single agent list item
+ */
+export function renderAgentItem(agent: AgentDisplayData): string {
+  const activityClass = getActivityClass(agent.lastSeenAt);
+  const displayId = truncateAgentId(agent.agentId);
+
+  return `
+    <div class="list-item agent-item ${activityClass}" data-agent-id="${escapeHtml(agent.agentId)}">
+      <div class="agent-header">
+        <span class="agent-indicator ${activityClass}"></span>
+        <span class="agent-id" title="${escapeHtml(agent.agentId)}">${escapeHtml(displayId)}</span>
+      </div>
+      <div class="agent-stats">
+        <span class="stat-item" title="Events">
+          <span class="stat-icon">📊</span>
+          <span class="stat-value">${agent.eventCount}</span>
+        </span>
+        <span class="stat-item" title="Spaces">
+          <span class="stat-icon">🏠</span>
+          <span class="stat-value">${agent.spaceCount}</span>
+        </span>
+        <span class="stat-item" title="Threads">
+          <span class="stat-icon">🧵</span>
+          <span class="stat-value">${agent.threadCount}</span>
+        </span>
+      </div>
+      <div class="agent-time">${formatRelativeTime(agent.lastSeenAt)}</div>
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for agent list
+ */
+export function renderAgentEmptyState(): string {
+  return `
+    <div class="empty-state">
+      <div class="empty-state-icon">👤</div>
+      <div class="empty-state-text">No agents yet</div>
+      <div class="empty-state-hint">Agents will appear when events are received</div>
+    </div>
+  `;
+}
+
+/**
+ * Get AgentList-specific CSS styles
+ */
+export function getAgentListStyles(): string {
+  return `
+    /* Agent list styles */
+    .agent-item {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 10px 12px;
+      border-left: 3px solid var(--border-color);
+      transition: border-color 0.2s, background 0.2s;
+    }
+
+    .agent-item.active {
+      border-left-color: var(--accent-green);
+      background: rgba(63, 185, 80, 0.05);
+    }
+
+    .agent-item.recent {
+      border-left-color: var(--accent-yellow);
+    }
+
+    .agent-item.idle {
+      border-left-color: var(--accent-gray);
+      opacity: 0.7;
+    }
+
+    .agent-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .agent-indicator {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent-gray);
+    }
+
+    .agent-indicator.active {
+      background: var(--accent-green);
+      box-shadow: 0 0 6px var(--accent-green);
+    }
+
+    .agent-indicator.recent {
+      background: var(--accent-yellow);
+    }
+
+    .agent-id {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-primary);
+      font-family: monospace;
+    }
+
+    .agent-stats {
+      display: flex;
+      gap: 12px;
+      font-size: 11px;
+    }
+
+    .stat-item {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      color: var(--text-secondary);
+    }
+
+    .stat-icon {
+      font-size: 10px;
+    }
+
+    .stat-value {
+      color: var(--text-primary);
+      font-weight: 500;
+    }
+
+    .agent-time {
+      font-size: 10px;
+      color: var(--text-secondary);
+    }
+  `;
+}

--- a/src/proofportal/templates/components/SpaceView.ts
+++ b/src/proofportal/templates/components/SpaceView.ts
@@ -21,6 +21,10 @@ export interface SpaceMemberData {
 
 /**
  * Space display data
+ *
+ * Note: visibility field was removed as it's not currently available
+ * from ProofComm events. Can be added back when Space metadata includes
+ * visibility information.
  */
 export interface SpaceDisplayData {
   spaceId: string;
@@ -29,7 +33,6 @@ export interface SpaceDisplayData {
   memberCount: number;
   messageCount: number;
   lastActivityAt: number;
-  visibility: 'public' | 'private' | 'unknown';
 }
 
 /**
@@ -46,19 +49,9 @@ export function formatMessageCount(count: number): string {
   return count === 1 ? '1 message' : `${count} messages`;
 }
 
-/**
- * Get visibility badge
- */
-export function getVisibilityBadge(visibility: string): string {
-  switch (visibility) {
-    case 'public':
-      return '<span class="visibility-badge public">🌐 public</span>';
-    case 'private':
-      return '<span class="visibility-badge private">🔒 private</span>';
-    default:
-      return '';
-  }
-}
+// Note: getVisibilityBadge was removed as visibility is not currently
+// available from ProofComm events. The function can be restored when
+// Space metadata includes visibility information.
 
 /**
  * Truncate space ID for display
@@ -89,7 +82,6 @@ export function renderMemberBadge(member: SpaceMemberData): string {
  */
 export function renderSpaceCard(space: SpaceDisplayData): string {
   const displayName = space.spaceName || truncateSpaceId(space.spaceId);
-  const visibilityBadge = getVisibilityBadge(space.visibility);
   const memberBadges = space.members
     .slice(0, 5)
     .map(m => renderMemberBadge(m))
@@ -103,7 +95,6 @@ export function renderSpaceCard(space: SpaceDisplayData): string {
           <span class="space-icon">🏠</span>
           <span class="space-name" title="${escapeHtml(space.spaceId)}">${escapeHtml(displayName)}</span>
         </div>
-        ${visibilityBadge}
       </div>
       <div class="space-stats">
         <div class="space-stat">
@@ -177,22 +168,6 @@ export function getSpaceViewStyles(): string {
       font-size: 13px;
       font-weight: 600;
       color: var(--text-primary);
-    }
-
-    .visibility-badge {
-      font-size: 10px;
-      padding: 2px 6px;
-      border-radius: 10px;
-    }
-
-    .visibility-badge.public {
-      background: rgba(63, 185, 80, 0.15);
-      color: var(--accent-green);
-    }
-
-    .visibility-badge.private {
-      background: rgba(210, 153, 34, 0.15);
-      color: var(--accent-yellow);
     }
 
     .space-stats {

--- a/src/proofportal/templates/components/SpaceView.ts
+++ b/src/proofportal/templates/components/SpaceView.ts
@@ -1,0 +1,295 @@
+/**
+ * ProofPortal - SpaceView Component
+ * Phase 4.5: Space visualization
+ *
+ * Displays autonomous spaces with:
+ * - Member list with join/leave tracking
+ * - Message count and activity
+ * - G3 representative event display
+ */
+
+import { escapeHtml } from '../layout.js';
+
+/**
+ * Space member data
+ */
+export interface SpaceMemberData {
+  agentId: string;
+  isActive: boolean;
+  joinedAt: number;
+}
+
+/**
+ * Space display data
+ */
+export interface SpaceDisplayData {
+  spaceId: string;
+  spaceName: string | null;
+  members: SpaceMemberData[];
+  memberCount: number;
+  messageCount: number;
+  lastActivityAt: number;
+  visibility: 'public' | 'private' | 'unknown';
+}
+
+/**
+ * Format member count with proper pluralization
+ */
+export function formatMemberCount(count: number): string {
+  return count === 1 ? '1 member' : `${count} members`;
+}
+
+/**
+ * Format message count with proper pluralization
+ */
+export function formatMessageCount(count: number): string {
+  return count === 1 ? '1 message' : `${count} messages`;
+}
+
+/**
+ * Get visibility badge
+ */
+export function getVisibilityBadge(visibility: string): string {
+  switch (visibility) {
+    case 'public':
+      return '<span class="visibility-badge public">🌐 public</span>';
+    case 'private':
+      return '<span class="visibility-badge private">🔒 private</span>';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Truncate space ID for display
+ */
+export function truncateSpaceId(spaceId: string): string {
+  if (spaceId.length <= 12) return spaceId;
+  return spaceId.slice(0, 8) + '…';
+}
+
+/**
+ * Render a member avatar/badge
+ */
+export function renderMemberBadge(member: SpaceMemberData): string {
+  const initial = member.agentId.charAt(0).toUpperCase();
+  const activeClass = member.isActive ? 'active' : '';
+  const shortId = member.agentId.slice(0, 8);
+
+  return `
+    <div class="member-badge ${activeClass}" title="${escapeHtml(member.agentId)}">
+      <span class="member-avatar">${initial}</span>
+      <span class="member-id">${escapeHtml(shortId)}</span>
+    </div>
+  `;
+}
+
+/**
+ * Render a space card
+ */
+export function renderSpaceCard(space: SpaceDisplayData): string {
+  const displayName = space.spaceName || truncateSpaceId(space.spaceId);
+  const visibilityBadge = getVisibilityBadge(space.visibility);
+  const memberBadges = space.members
+    .slice(0, 5)
+    .map(m => renderMemberBadge(m))
+    .join('');
+  const moreMembers = space.memberCount > 5 ? `<span class="more-members">+${space.memberCount - 5}</span>` : '';
+
+  return `
+    <div class="space-card" data-space-id="${escapeHtml(space.spaceId)}">
+      <div class="space-header">
+        <div class="space-title">
+          <span class="space-icon">🏠</span>
+          <span class="space-name" title="${escapeHtml(space.spaceId)}">${escapeHtml(displayName)}</span>
+        </div>
+        ${visibilityBadge}
+      </div>
+      <div class="space-stats">
+        <div class="space-stat">
+          <span class="stat-label">Members</span>
+          <span class="stat-value">${space.memberCount}</span>
+        </div>
+        <div class="space-stat">
+          <span class="stat-label">Messages</span>
+          <span class="stat-value">${space.messageCount}</span>
+        </div>
+      </div>
+      <div class="space-members">
+        ${memberBadges}
+        ${moreMembers}
+      </div>
+      <div class="space-activity">
+        <span class="activity-indicator ${space.messageCount > 0 ? 'active' : ''}"></span>
+        <span class="activity-text">${space.messageCount > 0 ? 'Active' : 'Quiet'}</span>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for space view
+ */
+export function renderSpaceEmptyState(): string {
+  return `
+    <div class="empty-state">
+      <div class="empty-state-icon">🏠</div>
+      <div class="empty-state-text">No spaces yet</div>
+      <div class="empty-state-hint">Spaces appear when agents join or send messages</div>
+    </div>
+  `;
+}
+
+/**
+ * Get SpaceView-specific CSS styles
+ */
+export function getSpaceViewStyles(): string {
+  return `
+    /* Space view styles */
+    .space-card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      margin-bottom: 8px;
+      overflow: hidden;
+    }
+
+    .space-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 12px;
+      background: var(--bg-tertiary);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .space-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .space-icon {
+      font-size: 16px;
+    }
+
+    .space-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .visibility-badge {
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 10px;
+    }
+
+    .visibility-badge.public {
+      background: rgba(63, 185, 80, 0.15);
+      color: var(--accent-green);
+    }
+
+    .visibility-badge.private {
+      background: rgba(210, 153, 34, 0.15);
+      color: var(--accent-yellow);
+    }
+
+    .space-stats {
+      display: flex;
+      padding: 10px 12px;
+      gap: 20px;
+    }
+
+    .space-stat {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .space-stat .stat-label {
+      font-size: 10px;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+    }
+
+    .space-stat .stat-value {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--accent-blue);
+    }
+
+    .space-members {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      padding: 8px 12px;
+      border-top: 1px solid var(--border-color);
+    }
+
+    .member-badge {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 3px 8px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 12px;
+      font-size: 11px;
+    }
+
+    .member-badge.active {
+      border-color: var(--accent-green);
+      background: rgba(63, 185, 80, 0.1);
+    }
+
+    .member-avatar {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--accent-purple);
+      color: white;
+      font-size: 10px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .member-id {
+      font-family: monospace;
+      color: var(--text-secondary);
+    }
+
+    .more-members {
+      display: flex;
+      align-items: center;
+      padding: 3px 8px;
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .space-activity {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      background: var(--bg-tertiary);
+      border-top: 1px solid var(--border-color);
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .activity-indicator {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-gray);
+    }
+
+    .activity-indicator.active {
+      background: var(--accent-green);
+      animation: pulse 2s infinite;
+    }
+  `;
+}

--- a/src/proofportal/templates/components/ThreadPanel.ts
+++ b/src/proofportal/templates/components/ThreadPanel.ts
@@ -1,0 +1,337 @@
+/**
+ * ProofPortal - ThreadPanel Component
+ * Phase 4.4: Thread/trace visualization
+ *
+ * Displays events grouped by trace_id with:
+ * - Timeline visualization
+ * - Participant list
+ * - Event details on expansion
+ */
+
+import { escapeHtml } from '../layout.js';
+import type { ProofCommAction } from '../../types.js';
+
+/**
+ * Event display data for thread
+ */
+export interface ThreadEventData {
+  id: string;
+  action: ProofCommAction;
+  eventKind: string;
+  timestamp: number;
+  agentId: string | null;
+  spaceId: string | null;
+  spaceName: string | null;
+  preview: string | null;
+}
+
+/**
+ * Thread display data
+ */
+export interface ThreadDisplayData {
+  traceId: string;
+  events: ThreadEventData[];
+  participants: string[];
+  startedAt: number;
+  lastActivityAt: number;
+  duration: number;
+}
+
+/**
+ * Format timestamp for display
+ */
+export function formatTimestamp(ts: number): string {
+  const date = new Date(ts);
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+/**
+ * Format duration in human-readable format
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  return `${min}m ${sec % 60}s`;
+}
+
+/**
+ * Get action badge class
+ */
+export function getActionClass(action: ProofCommAction): string {
+  switch (action) {
+    case 'message':
+    case 'created':
+      return 'action-success';
+    case 'joined':
+    case 'activated':
+      return 'action-info';
+    case 'left':
+    case 'deactivated':
+      return 'action-warning';
+    case 'delivery_failed':
+    case 'deleted':
+      return 'action-error';
+    default:
+      return 'action-default';
+  }
+}
+
+/**
+ * Get event kind icon
+ */
+export function getEventKindIcon(eventKind: string): string {
+  switch (eventKind) {
+    case 'proofcomm_space':
+      return '🏠';
+    case 'proofcomm_skill':
+      return '🔧';
+    case 'proofcomm_document':
+      return '📄';
+    case 'proofcomm_route':
+      return '🔀';
+    default:
+      return '📌';
+  }
+}
+
+/**
+ * Truncate trace ID for display
+ */
+export function truncateTraceId(traceId: string): string {
+  if (traceId.length <= 12) return traceId;
+  return traceId.slice(0, 8) + '…' + traceId.slice(-4);
+}
+
+/**
+ * Render a single event in the timeline
+ */
+export function renderThreadEvent(event: ThreadEventData): string {
+  const icon = getEventKindIcon(event.eventKind);
+  const actionClass = getActionClass(event.action);
+  const agentDisplay = event.agentId ? escapeHtml(event.agentId.slice(0, 12)) : 'unknown';
+
+  return `
+    <div class="thread-event" data-event-id="${escapeHtml(event.id)}">
+      <div class="event-timeline-dot"></div>
+      <div class="event-content">
+        <div class="event-header">
+          <span class="event-icon">${icon}</span>
+          <span class="event-action ${actionClass}">${escapeHtml(event.action)}</span>
+          <span class="event-agent">${agentDisplay}</span>
+          <span class="event-time">${formatTimestamp(event.timestamp)}</span>
+        </div>
+        ${event.preview ? `<div class="event-preview">${escapeHtml(event.preview)}</div>` : ''}
+        ${event.spaceName ? `<div class="event-space">in ${escapeHtml(event.spaceName)}</div>` : ''}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render a thread card
+ */
+export function renderThreadCard(thread: ThreadDisplayData): string {
+  const shortId = truncateTraceId(thread.traceId);
+  const participantCount = thread.participants.length;
+  const eventCount = thread.events.length;
+
+  return `
+    <div class="thread-card" data-trace-id="${escapeHtml(thread.traceId)}">
+      <div class="thread-header">
+        <span class="thread-id" title="${escapeHtml(thread.traceId)}">${escapeHtml(shortId)}</span>
+        <span class="thread-meta">
+          <span class="thread-stat">${eventCount} events</span>
+          <span class="thread-stat">${participantCount} agents</span>
+        </span>
+      </div>
+      <div class="thread-timeline">
+        ${thread.events.slice(-5).map(e => renderThreadEvent(e)).join('')}
+        ${thread.events.length > 5 ? `<div class="thread-more">+${thread.events.length - 5} more</div>` : ''}
+      </div>
+      <div class="thread-footer">
+        <span class="thread-duration">${formatDuration(thread.duration)}</span>
+        <span class="thread-time">${formatTimestamp(thread.lastActivityAt)}</span>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for thread panel
+ */
+export function renderThreadEmptyState(): string {
+  return `
+    <div class="empty-state">
+      <div class="empty-state-icon">🧵</div>
+      <div class="empty-state-text">No threads yet</div>
+      <div class="empty-state-hint">Threads appear when traced events arrive</div>
+    </div>
+  `;
+}
+
+/**
+ * Get ThreadPanel-specific CSS styles
+ */
+export function getThreadPanelStyles(): string {
+  return `
+    /* Thread panel styles */
+    .thread-card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      margin-bottom: 8px;
+      overflow: hidden;
+    }
+
+    .thread-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 12px;
+      background: var(--bg-tertiary);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .thread-id {
+      font-family: monospace;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--accent-blue);
+    }
+
+    .thread-meta {
+      display: flex;
+      gap: 10px;
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .thread-stat {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .thread-timeline {
+      padding: 8px 12px;
+      position: relative;
+    }
+
+    .thread-timeline::before {
+      content: '';
+      position: absolute;
+      left: 20px;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: var(--border-color);
+    }
+
+    .thread-event {
+      display: flex;
+      gap: 10px;
+      padding: 6px 0;
+      position: relative;
+    }
+
+    .event-timeline-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--bg-secondary);
+      border: 2px solid var(--accent-blue);
+      z-index: 1;
+      flex-shrink: 0;
+      margin-top: 4px;
+    }
+
+    .event-content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .event-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .event-icon {
+      font-size: 12px;
+    }
+
+    .event-action {
+      font-size: 11px;
+      font-weight: 500;
+      padding: 1px 6px;
+      border-radius: 4px;
+    }
+
+    .action-success { background: rgba(63, 185, 80, 0.15); color: var(--accent-green); }
+    .action-info { background: rgba(0, 212, 255, 0.15); color: var(--accent-blue); }
+    .action-warning { background: rgba(210, 153, 34, 0.15); color: var(--accent-yellow); }
+    .action-error { background: rgba(248, 81, 73, 0.15); color: var(--accent-red); }
+    .action-default { background: var(--bg-tertiary); color: var(--text-secondary); }
+
+    .event-agent {
+      font-size: 11px;
+      color: var(--text-secondary);
+      font-family: monospace;
+    }
+
+    .event-time {
+      font-size: 10px;
+      color: var(--text-secondary);
+      margin-left: auto;
+    }
+
+    .event-preview {
+      font-size: 11px;
+      color: var(--text-secondary);
+      margin-top: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .event-space {
+      font-size: 10px;
+      color: var(--accent-purple);
+      margin-top: 2px;
+    }
+
+    .thread-more {
+      text-align: center;
+      font-size: 11px;
+      color: var(--text-secondary);
+      padding: 4px;
+      cursor: pointer;
+    }
+
+    .thread-more:hover {
+      color: var(--accent-blue);
+    }
+
+    .thread-footer {
+      display: flex;
+      justify-content: space-between;
+      padding: 8px 12px;
+      background: var(--bg-tertiary);
+      border-top: 1px solid var(--border-color);
+      font-size: 10px;
+      color: var(--text-secondary);
+    }
+
+    .thread-duration {
+      color: var(--accent-green);
+    }
+  `;
+}

--- a/src/proofportal/templates/components/index.ts
+++ b/src/proofportal/templates/components/index.ts
@@ -35,7 +35,6 @@ export {
   type SpaceDisplayData,
   formatMemberCount,
   formatMessageCount,
-  getVisibilityBadge,
   truncateSpaceId,
   renderMemberBadge,
   renderSpaceCard,

--- a/src/proofportal/templates/components/index.ts
+++ b/src/proofportal/templates/components/index.ts
@@ -1,0 +1,44 @@
+/**
+ * ProofPortal - Component exports
+ * Phase 4: ProofPortal MVP
+ */
+
+// AgentList
+export {
+  type AgentDisplayData,
+  formatRelativeTime,
+  truncateAgentId,
+  getActivityClass,
+  renderAgentItem,
+  renderAgentEmptyState,
+  getAgentListStyles,
+} from './AgentList.js';
+
+// ThreadPanel
+export {
+  type ThreadEventData,
+  type ThreadDisplayData,
+  formatTimestamp,
+  formatDuration,
+  getActionClass,
+  getEventKindIcon,
+  truncateTraceId,
+  renderThreadEvent,
+  renderThreadCard,
+  renderThreadEmptyState,
+  getThreadPanelStyles,
+} from './ThreadPanel.js';
+
+// SpaceView
+export {
+  type SpaceMemberData,
+  type SpaceDisplayData,
+  formatMemberCount,
+  formatMessageCount,
+  getVisibilityBadge,
+  truncateSpaceId,
+  renderMemberBadge,
+  renderSpaceCard,
+  renderSpaceEmptyState,
+  getSpaceViewStyles,
+} from './SpaceView.js';

--- a/src/proofportal/templates/dashboard.ts
+++ b/src/proofportal/templates/dashboard.ts
@@ -1,0 +1,79 @@
+/**
+ * ProofPortal - Dashboard template
+ * Phase 4: ProofPortal MVP
+ */
+
+import { renderLayout, escapeHtml } from './layout.js';
+import { getSseClientScript } from '../sse-client.js';
+
+/**
+ * Dashboard options
+ */
+export interface DashboardOptions {
+  generatedAt: string;
+}
+
+/**
+ * Render the main dashboard page
+ */
+export function renderDashboard(options: DashboardOptions): string {
+  const content = `
+  <main class="main">
+    <!-- Left Panel: Agents -->
+    <div class="panel">
+      <div class="panel-header">
+        Agents <span class="panel-count">0</span>
+      </div>
+      <div class="panel-content" id="agentList">
+        <div class="empty-state">
+          <div class="empty-state-icon">👤</div>
+          Waiting for events...
+        </div>
+      </div>
+    </div>
+
+    <!-- Center Panel: Threads -->
+    <div class="panel">
+      <div class="panel-header">
+        Threads <span class="panel-count">0</span>
+      </div>
+      <div class="panel-content" id="threadList">
+        <div class="empty-state">
+          <div class="empty-state-icon">🧵</div>
+          Waiting for events...
+        </div>
+      </div>
+    </div>
+
+    <!-- Right Panel: Spaces -->
+    <div class="panel">
+      <div class="panel-header">
+        Spaces <span class="panel-count">0</span>
+      </div>
+      <div class="panel-content" id="spaceList">
+        <div class="empty-state">
+          <div class="empty-state-icon">🏠</div>
+          Waiting for events...
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="stats-bar">
+    <div class="stat">
+      <span>Generated:</span>
+      <span class="stat-value">${escapeHtml(options.generatedAt)}</span>
+    </div>
+    <div class="stat">
+      <span>Mode:</span>
+      <span class="stat-value">Real-time SSE</span>
+    </div>
+  </footer>
+  `;
+
+  return renderLayout({
+    title: 'ProofPortal - Agent Communication',
+    content,
+    scripts: getSseClientScript(),
+  });
+}

--- a/src/proofportal/templates/index.ts
+++ b/src/proofportal/templates/index.ts
@@ -1,0 +1,7 @@
+/**
+ * ProofPortal - Template exports
+ * Phase 4: ProofPortal MVP
+ */
+
+export { renderLayout, escapeHtml, formatTime, getPortalStyles } from './layout.js';
+export { renderDashboard, type DashboardOptions } from './dashboard.js';

--- a/src/proofportal/templates/index.ts
+++ b/src/proofportal/templates/index.ts
@@ -3,5 +3,5 @@
  * Phase 4: ProofPortal MVP
  */
 
-export { renderLayout, escapeHtml, formatTime, getPortalStyles } from './layout.js';
+export { renderLayout, escapeHtml, formatTime, getPortalStyles, getComponentStyles } from './layout.js';
 export { renderDashboard, type DashboardOptions } from './dashboard.js';

--- a/src/proofportal/templates/layout.ts
+++ b/src/proofportal/templates/layout.ts
@@ -3,6 +3,10 @@
  * Phase 4: ProofPortal MVP
  */
 
+import { getAgentListStyles } from './components/AgentList.js';
+import { getThreadPanelStyles } from './components/ThreadPanel.js';
+import { getSpaceViewStyles } from './components/SpaceView.js';
+
 /**
  * Escape HTML special characters
  */
@@ -293,7 +297,24 @@ export function getPortalStyles(): string {
       color: var(--text-primary);
       font-weight: 500;
     }
+
+    /* Empty state hint */
+    .empty-state-text {
+      margin-bottom: 4px;
+    }
+
+    .empty-state-hint {
+      font-size: 11px;
+      opacity: 0.7;
+    }
   `;
+}
+
+/**
+ * Get all component styles combined
+ */
+export function getComponentStyles(): string {
+  return getAgentListStyles() + getThreadPanelStyles() + getSpaceViewStyles();
 }
 
 /**
@@ -312,6 +333,7 @@ export function renderLayout(options: {
   <title>${escapeHtml(options.title)}</title>
   <style>
 ${getPortalStyles()}
+${getComponentStyles()}
   </style>
 </head>
 <body data-app="portal">

--- a/src/proofportal/templates/layout.ts
+++ b/src/proofportal/templates/layout.ts
@@ -1,0 +1,334 @@
+/**
+ * ProofPortal - Base HTML layout
+ * Phase 4: ProofPortal MVP
+ */
+
+/**
+ * Escape HTML special characters
+ */
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Format timestamp for display
+ */
+export function formatTime(ts: number): string {
+  const date = new Date(ts);
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+/**
+ * Get portal-specific CSS styles
+ */
+export function getPortalStyles(): string {
+  return `
+    :root {
+      --bg-primary: #0d1117;
+      --bg-secondary: #161b22;
+      --bg-tertiary: #21262d;
+      --border-color: #30363d;
+      --text-primary: #e6edf3;
+      --text-secondary: #8b949e;
+      --accent-blue: #00d4ff;
+      --accent-green: #3fb950;
+      --accent-yellow: #d29922;
+      --accent-red: #f85149;
+      --accent-purple: #a371f7;
+      --accent-gray: #6e7681;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      color: var(--text-primary);
+      background: var(--bg-primary);
+      min-height: 100vh;
+    }
+
+    /* Header */
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px 24px;
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border-color);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .header-title {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--text-primary);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .header-title::before {
+      content: '';
+      width: 8px;
+      height: 8px;
+      background: var(--accent-purple);
+      border-radius: 50%;
+    }
+
+    .header-meta {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      font-size: 12px;
+      color: var(--text-secondary);
+    }
+
+    /* Connection status indicator */
+    .connection-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 12px;
+      font-size: 11px;
+    }
+
+    .connection-status.connected {
+      border-color: rgba(63, 185, 80, 0.3);
+    }
+
+    .connection-status.disconnected {
+      border-color: rgba(248, 81, 73, 0.3);
+    }
+
+    .connection-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-gray);
+    }
+
+    .connected .connection-dot {
+      background: var(--accent-green);
+      animation: pulse 2s infinite;
+    }
+
+    .disconnected .connection-dot {
+      background: var(--accent-red);
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    /* Main layout */
+    .main {
+      display: grid;
+      grid-template-columns: 280px 1fr 320px;
+      gap: 1px;
+      background: var(--border-color);
+      min-height: calc(100vh - 49px);
+    }
+
+    .panel {
+      background: var(--bg-primary);
+      overflow-y: auto;
+    }
+
+    .panel-header {
+      padding: 12px 16px;
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border-color);
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    .panel-count {
+      font-weight: normal;
+      color: var(--accent-blue);
+    }
+
+    .panel-content {
+      padding: 8px;
+    }
+
+    /* List items */
+    .list-item {
+      padding: 10px 12px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+      margin-bottom: 6px;
+      cursor: pointer;
+      transition: border-color 0.15s;
+    }
+
+    .list-item:hover {
+      border-color: var(--accent-blue);
+    }
+
+    .list-item-title {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-primary);
+      margin-bottom: 4px;
+    }
+
+    .list-item-meta {
+      font-size: 11px;
+      color: var(--text-secondary);
+      display: flex;
+      gap: 8px;
+    }
+
+    /* Badge styles */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 6px;
+      border-radius: 10px;
+      font-size: 10px;
+      font-weight: 500;
+    }
+
+    .badge-space { background: rgba(163, 113, 247, 0.15); color: var(--accent-purple); }
+    .badge-agent { background: rgba(0, 212, 255, 0.15); color: var(--accent-blue); }
+    .badge-message { background: rgba(63, 185, 80, 0.15); color: var(--accent-green); }
+    .badge-skill { background: rgba(210, 153, 34, 0.15); color: var(--accent-yellow); }
+
+    /* Event timeline */
+    .event-item {
+      padding: 8px 12px;
+      background: var(--bg-secondary);
+      border-left: 3px solid var(--border-color);
+      margin-bottom: 4px;
+      font-size: 12px;
+    }
+
+    .event-item.space { border-left-color: var(--accent-purple); }
+    .event-item.skill { border-left-color: var(--accent-yellow); }
+    .event-item.document { border-left-color: var(--accent-blue); }
+
+    .event-time {
+      color: var(--text-secondary);
+      font-size: 10px;
+      font-family: monospace;
+    }
+
+    .event-action {
+      color: var(--text-primary);
+      font-weight: 500;
+    }
+
+    .event-preview {
+      color: var(--text-secondary);
+      font-size: 11px;
+      margin-top: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* Empty state */
+    .empty-state {
+      padding: 40px 20px;
+      text-align: center;
+      color: var(--text-secondary);
+    }
+
+    .empty-state-icon {
+      font-size: 32px;
+      margin-bottom: 12px;
+      opacity: 0.5;
+    }
+
+    /* Stats bar */
+    .stats-bar {
+      display: flex;
+      gap: 16px;
+      padding: 8px 16px;
+      background: var(--bg-tertiary);
+      border-top: 1px solid var(--border-color);
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .stat-value {
+      color: var(--text-primary);
+      font-weight: 500;
+    }
+  `;
+}
+
+/**
+ * Render the base layout
+ */
+export function renderLayout(options: {
+  title: string;
+  content: string;
+  scripts?: string;
+}): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(options.title)}</title>
+  <style>
+${getPortalStyles()}
+  </style>
+</head>
+<body data-app="portal">
+  <header class="header">
+    <div class="header-title">ProofPortal</div>
+    <div class="header-meta">
+      <div class="connection-status disconnected" id="connectionStatus">
+        <span class="connection-dot"></span>
+        <span class="connection-text">Disconnected</span>
+      </div>
+      <span id="eventCount">0 events</span>
+    </div>
+  </header>
+  ${options.content}
+  <script>
+${options.scripts ?? ''}
+  </script>
+</body>
+</html>`;
+}

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -1,0 +1,256 @@
+/**
+ * ProofPortal - Type definitions
+ * Phase 4: ProofPortal MVP
+ *
+ * State management types for real-time agent communication visualization.
+ * State keys follow vault 3040 specification: trace_id / space_id / agent_id
+ */
+
+import type { GatewayEventKind } from '../db/types.js';
+
+/**
+ * ProofComm event kinds that Portal observes
+ */
+export const PROOFCOMM_EVENT_KINDS: GatewayEventKind[] = [
+  'proofcomm_space',
+  'proofcomm_skill',
+  'proofcomm_document',
+  'proofcomm_route',
+];
+
+/**
+ * ProofComm action types (from events.ts)
+ */
+export type ProofCommAction =
+  // space
+  | 'created' | 'joined' | 'left' | 'message' | 'delivery_failed' | 'updated' | 'deleted'
+  // skill
+  | 'search' | 'match'
+  // document
+  | 'activated' | 'deactivated' | 'context_updated'
+  // route
+  | 'resolved' | 'dispatched';
+
+/**
+ * SSE event data received from Gateway
+ */
+export interface PortalSseEvent {
+  event_kind: GatewayEventKind;
+  client_id: string;
+  ts: number;
+  request_id: string;
+  trace_id?: string | null;
+  target_id?: string | null;
+  method?: string | null;
+  metadata?: ProofCommMetadata | null;
+}
+
+/**
+ * ProofComm metadata from SSE events
+ */
+export interface ProofCommMetadata {
+  action: ProofCommAction;
+  space_id?: string;
+  space_name?: string;
+  agent_id?: string;
+  agent_name?: string;
+  doc_target_id?: string;
+  doc_path?: string;
+  skill_id?: string;
+  skill_name?: string;
+  match_score?: number;
+  message_id?: string;
+  message_preview?: string;
+  task_id?: string;
+  recipient_count?: number;
+  failed_count?: number;
+}
+
+/**
+ * Display-friendly event for UI rendering
+ */
+export interface PortalEventDisplay {
+  id: string;
+  eventKind: GatewayEventKind;
+  action: ProofCommAction;
+  timestamp: number;
+  traceId: string | null;
+  clientId: string;
+  agentId: string | null;
+  spaceId: string | null;
+  spaceName: string | null;
+  preview: string | null;
+  metadata: ProofCommMetadata;
+}
+
+/**
+ * Thread state - events grouped by trace_id
+ */
+export interface ThreadState {
+  traceId: string;
+  events: PortalEventDisplay[];
+  participants: Set<string>;  // agent_ids
+  startedAt: number;
+  lastActivityAt: number;
+}
+
+/**
+ * Space state - events grouped by space_id
+ */
+export interface SpaceState {
+  spaceId: string;
+  spaceName: string | null;
+  members: Set<string>;  // agent_ids (from join/leave events)
+  events: PortalEventDisplay[];
+  messageCount: number;
+  lastActivityAt: number;
+}
+
+/**
+ * Agent state - activity grouped by agent_id
+ */
+export interface AgentState {
+  agentId: string;
+  traceIds: Set<string>;
+  spaceIds: Set<string>;
+  eventCount: number;
+  lastSeenAt: number;
+}
+
+/**
+ * Portal state root
+ */
+export interface PortalState {
+  /** Events grouped by trace_id */
+  threads: Map<string, ThreadState>;
+  /** Events grouped by space_id */
+  spaces: Map<string, SpaceState>;
+  /** Activity grouped by agent_id */
+  agents: Map<string, AgentState>;
+  /** SSE connection status */
+  connected: boolean;
+  /** Last received event timestamp */
+  lastEventTs: number;
+  /** Total event count */
+  eventCount: number;
+}
+
+/**
+ * Create initial empty state
+ */
+export function createInitialState(): PortalState {
+  return {
+    threads: new Map(),
+    spaces: new Map(),
+    agents: new Map(),
+    connected: false,
+    lastEventTs: 0,
+    eventCount: 0,
+  };
+}
+
+/**
+ * Convert SSE event to display format
+ */
+export function toDisplayEvent(event: PortalSseEvent): PortalEventDisplay {
+  const metadata = event.metadata ?? { action: 'message' as ProofCommAction };
+  return {
+    id: event.request_id,
+    eventKind: event.event_kind,
+    action: metadata.action,
+    timestamp: event.ts,
+    traceId: event.trace_id ?? null,
+    clientId: event.client_id,
+    agentId: metadata.agent_id ?? null,
+    spaceId: metadata.space_id ?? null,
+    spaceName: metadata.space_name ?? null,
+    preview: metadata.message_preview ?? null,
+    metadata,
+  };
+}
+
+/**
+ * Update state with a new event
+ */
+export function updateState(state: PortalState, event: PortalSseEvent): PortalState {
+  const display = toDisplayEvent(event);
+  const now = event.ts;
+
+  // Update thread state
+  if (display.traceId) {
+    let thread = state.threads.get(display.traceId);
+    if (!thread) {
+      thread = {
+        traceId: display.traceId,
+        events: [],
+        participants: new Set(),
+        startedAt: now,
+        lastActivityAt: now,
+      };
+      state.threads.set(display.traceId, thread);
+    }
+    thread.events.push(display);
+    thread.lastActivityAt = now;
+    if (display.agentId) {
+      thread.participants.add(display.agentId);
+    }
+  }
+
+  // Update space state
+  if (display.spaceId) {
+    let space = state.spaces.get(display.spaceId);
+    if (!space) {
+      space = {
+        spaceId: display.spaceId,
+        spaceName: display.spaceName,
+        members: new Set(),
+        events: [],
+        messageCount: 0,
+        lastActivityAt: now,
+      };
+      state.spaces.set(display.spaceId, space);
+    }
+    space.events.push(display);
+    space.lastActivityAt = now;
+    if (display.spaceName) {
+      space.spaceName = display.spaceName;
+    }
+
+    // Track membership changes
+    if (display.action === 'joined' && display.agentId) {
+      space.members.add(display.agentId);
+    } else if (display.action === 'left' && display.agentId) {
+      space.members.delete(display.agentId);
+    } else if (display.action === 'message') {
+      space.messageCount++;
+    }
+  }
+
+  // Update agent state
+  const agentId = display.agentId ?? display.clientId;
+  let agent = state.agents.get(agentId);
+  if (!agent) {
+    agent = {
+      agentId,
+      traceIds: new Set(),
+      spaceIds: new Set(),
+      eventCount: 0,
+      lastSeenAt: now,
+    };
+    state.agents.set(agentId, agent);
+  }
+  agent.eventCount++;
+  agent.lastSeenAt = now;
+  if (display.traceId) {
+    agent.traceIds.add(display.traceId);
+  }
+  if (display.spaceId) {
+    agent.spaceIds.add(display.spaceId);
+  }
+
+  // Update global state
+  state.lastEventTs = now;
+  state.eventCount++;
+
+  return state;
+}

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -80,7 +80,8 @@ export interface PortalEventDisplay {
   spaceId: string | null;
   spaceName: string | null;
   preview: string | null;
-  metadata: ProofCommMetadata;
+  /** Metadata from source event, or minimal fallback if source had none */
+  metadata: Partial<ProofCommMetadata> & { action: ProofCommAction };
 }
 
 /**
@@ -170,9 +171,15 @@ export function toDisplayEvent(event: PortalSseEvent): PortalEventDisplay {
 }
 
 /**
- * Update state with a new event
+ * Apply event to state (mutates state in place)
+ *
+ * This function intentionally mutates the state object for performance.
+ * The Maps and Sets are updated in place rather than creating new copies.
+ *
+ * @param state - Portal state to mutate
+ * @param event - SSE event to apply
  */
-export function updateState(state: PortalState, event: PortalSseEvent): PortalState {
+export function applyEvent(state: PortalState, event: PortalSseEvent): void {
   const display = toDisplayEvent(event);
   const now = event.ts;
 
@@ -251,6 +258,4 @@ export function updateState(state: PortalState, event: PortalSseEvent): PortalSt
   // Update global state
   state.lastEventTs = now;
   state.eventCount++;
-
-  return state;
 }


### PR DESCRIPTION
## Summary
- **Phase 4.1**: ProofPortal 基盤 - SSE ベースリアルタイム可視化 UI の基本構造
- **Phase 4.3-4.6**: UI コンポーネント実装 - AgentList, ThreadPanel, SpaceView

## 実装内容

### ProofPortal 概要
ProofComm エージェント通信を可視化する読み取り専用 SSE ベース UI。Gateway `/portal` ルートとして統合。

### Phase 4.1 - Foundation
- `src/proofportal/types.ts` - PortalState, ThreadState, SpaceState, AgentState インターフェース
- `src/proofportal/templates/layout.ts` - ダークテーマ HTML テンプレート
- `src/proofportal/templates/dashboard.ts` - 3 パネルダッシュボード
- `src/proofportal/sse-client.ts` - ブラウザ側 SSE クライアント (EventSource)
- `src/proofportal/routes.ts` - Fastify ルート登録 (/portal, /portal/api/status)
- Gateway server.ts 統合

### Phase 4.3-4.6 - Components
| コンポーネント | 機能 |
|--------------|------|
| AgentList | アクティビティ表示 (active/recent/idle)、イベント/スペース/スレッドカウント |
| ThreadPanel | trace_id カード、イベント数、参加者数、duration 表示 |
| SpaceView | メンバーバッジ、メッセージカウント、Active/Quiet ステータス |

### State Keys (設計書 3040 準拠)
```typescript
interface PortalState {
  threads: Map<string, ThreadState>;   // key: trace_id
  spaces: Map<string, SpaceState>;     // key: space_id
  agents: Map<string, AgentState>;     // key: agent_id
}
```

## Test plan
- [ ] `npm run build` 成功
- [ ] `npm test -- src/proofportal` 18 tests pass
- [ ] Gateway 起動後、`/portal` でダッシュボード表示
- [ ] SSE 接続インジケーター表示
- [ ] proofcomm イベント発生時にリアルタイム更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)