### PR TITLE
feat(proofguild): Phase 5 - Guild system for agent visualization

### DIFF
--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -29,6 +29,10 @@ import { buildDocumentRoute, buildSpaceRoute } from '../proofcomm/routing.js';
 import { emitDocumentEvent, emitSkillEvent } from '../proofcomm/events.js';
 import type { AuditLogger } from './audit.js';
 import type { SpaceVisibility, MemberRole } from '../db/types.js';
+import {
+  registerGuildAgent,
+  type GuildRegisterRequest,
+} from '../proofcomm/guild/index.js';
 
 /**
  * Document registration request body
@@ -1268,5 +1272,51 @@ export function registerProofCommRoutes(
     }
 
     return reply.code(204).send();
+  });
+
+  // ============================================================================
+  // Guild Registration (Phase 5: ProofGuild)
+  // ============================================================================
+
+  // POST /proofcomm/guild/register - Self-register an external agent
+  fastify.post<{
+    Body: GuildRegisterRequest;
+  }>('/proofcomm/guild/register', {
+    // Note: No preHandler auth - this endpoint allows unauthenticated registration
+    schema: {
+      body: {
+        type: 'object',
+        required: ['url'],
+        properties: {
+          url: { type: 'string', minLength: 1 },
+          name: { type: 'string' },
+        },
+      },
+    },
+  }, async (request, reply) => {
+    const clientIp = request.ip || 'unknown';
+
+    const result = await registerGuildAgent(request.body, {
+      targetsStore,
+      auditLogger: options.auditLogger,
+      clientIp,
+      baseOptions: {
+        requestId: request.requestId,
+        traceId: request.headers['x-trace-id'] as string | undefined,
+        clientId: clientIp, // Use IP as client ID for unauthenticated requests
+      },
+      allowLocal: process.env.NODE_ENV === 'development',
+    });
+
+    if (!result.ok) {
+      return reply.code(result.statusCode || 500).send({
+        error: {
+          code: 'REGISTRATION_FAILED',
+          message: result.error,
+        },
+      });
+    }
+
+    return reply.code(201).send(result.response);
   });
 }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -4,7 +4,7 @@
  * Phase 8.2: Bearer Token Authentication
  * Phase 8.3: MCP Proxy
  * Phase 8.4: A2A Proxy
- * Phase 9.4: ProofPortal integration
+ * Phase 4: ProofPortal integration
  */
 
 import Fastify, { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
@@ -209,7 +209,7 @@ export function createGatewayServer(
 
     log.info({ event: 'proofcomm_routes_enabled', configDir });
 
-    // ProofPortal routes (Phase 9.4)
+    // ProofPortal routes (Phase 4)
     // Read-only SSE-based visualization UI
     registerPortalRoutes(server);
     log.info({ event: 'portal_routes_enabled', path: '/portal' });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -4,6 +4,7 @@
  * Phase 8.2: Bearer Token Authentication
  * Phase 8.3: MCP Proxy
  * Phase 8.4: A2A Proxy
+ * Phase 9.4: ProofPortal integration
  */
 
 import Fastify, { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
@@ -16,6 +17,7 @@ import { createA2AProxyHandler, A2AProxyRequest } from './a2aProxy.js';
 import { createAuditLogger, AuditLogger } from './audit.js';
 import { sseStreamHandler, getSseManager } from './sse.js';
 import { registerProofCommRoutes } from './proofcommProxy.js';
+import { registerPortalRoutes } from '../proofportal/index.js';
 
 export interface GatewayServer {
   /** Fastify instance */
@@ -206,6 +208,11 @@ export function createGatewayServer(
     });
 
     log.info({ event: 'proofcomm_routes_enabled', configDir });
+
+    // ProofPortal routes (Phase 9.4)
+    // Read-only SSE-based visualization UI
+    registerPortalRoutes(server);
+    log.info({ event: 'portal_routes_enabled', path: '/portal' });
   }
 
   // Graceful shutdown handlers

--- a/src/proofcomm/events.ts
+++ b/src/proofcomm/events.ts
@@ -43,6 +43,8 @@ export type ProofCommAction =
   | 'delivery_failed'
   | 'deleted'
   | 'updated'
+  // guild (Phase 5)
+  | 'registered'
   // skill
   | 'search'
   | 'match'
@@ -173,15 +175,15 @@ export function emitProofCommEvent(
  */
 export function emitSpaceEvent(
   auditLogger: AuditLogger,
-  action: 'created' | 'joined' | 'left' | 'message' | 'delivery_failed' | 'deleted' | 'updated',
-  metadata: Omit<ProofCommMetadata, 'action'> & { space_id: string },
+  action: 'created' | 'joined' | 'left' | 'message' | 'delivery_failed' | 'deleted' | 'updated' | 'registered',
+  metadata: Omit<ProofCommMetadata, 'action'> & { space_id?: string; agent_id?: string },
   baseOptions: ProofCommEventBaseOptions
 ): string {
   return emitProofCommEvent(
     auditLogger,
     'proofcomm_space',
     { ...metadata, action },
-    { ...baseOptions, target: baseOptions.target ?? metadata.space_id }
+    { ...baseOptions, target: baseOptions.target ?? metadata.space_id ?? metadata.agent_id }
   );
 }
 
@@ -288,7 +290,7 @@ export function isProofCommEventKind(kind: string): kind is ProofCommEventKind {
  */
 export function isValidAction(kind: ProofCommEventKind, action: string): boolean {
   const validActions: Record<ProofCommEventKind, string[]> = {
-    proofcomm_space: ['created', 'joined', 'left', 'message', 'delivery_failed', 'deleted', 'updated'],
+    proofcomm_space: ['created', 'joined', 'left', 'message', 'delivery_failed', 'deleted', 'updated', 'registered'],
     proofcomm_skill: ['search', 'match', 'refresh'],
     proofcomm_document: ['activated', 'deactivated', 'context_updated'],
     proofcomm_route: ['resolved', 'dispatched'],

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -1,0 +1,39 @@
+/**
+ * ProofGuild - Registration tests
+ * Phase 5: ProofGuild
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  validateGuildToken,
+  getGuildTokenCount,
+  cleanupGuildTokens,
+} from '../register.js';
+
+describe('ProofGuild Registration', () => {
+  describe('validateGuildToken', () => {
+    it('should return null for invalid token', () => {
+      const result = validateGuildToken('invalid-token-123');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty token', () => {
+      const result = validateGuildToken('');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getGuildTokenCount', () => {
+    it('should return number of registered tokens', () => {
+      const count = getGuildTokenCount();
+      expect(typeof count).toBe('number');
+      expect(count).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('cleanupGuildTokens', () => {
+    it('should not throw when called', () => {
+      expect(() => cleanupGuildTokens()).not.toThrow();
+    });
+  });
+});

--- a/src/proofcomm/guild/index.ts
+++ b/src/proofcomm/guild/index.ts
@@ -1,0 +1,17 @@
+/**
+ * ProofGuild Module
+ * Phase 5: ProofGuild
+ *
+ * Agent self-registration and Guild membership management.
+ */
+
+export {
+  type GuildRegisterRequest,
+  type GuildRegisterResponse,
+  type GuildRegisterResult,
+  type RegisterAgentOptions,
+  registerGuildAgent,
+  validateGuildToken,
+  getGuildTokenCount,
+  cleanupGuildTokens,
+} from './register.js';

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -1,0 +1,321 @@
+/**
+ * ProofGuild - Agent Self-Registration
+ * Phase 5: ProofGuild
+ *
+ * Allows external agents (OpenClaw, PicoClaw, etc.) to self-register
+ * with the Guild and receive a Bearer token for subsequent API calls.
+ */
+
+import { randomBytes, createHmac } from 'crypto';
+import { fetchAgentCard, type FetchAgentCardResult } from '../../a2a/agent-card.js';
+import { TargetsStore, type TargetWithConfig } from '../../db/targets-store.js';
+import { emitSpaceEvent, type ProofCommEventBaseOptions } from '../events.js';
+import type { AuditLogger } from '../../gateway/audit.js';
+import { ulid } from 'ulid';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Request body for guild registration
+ */
+export interface GuildRegisterRequest {
+  /** Agent base URL (AgentCard will be fetched from this URL) */
+  url: string;
+  /** Optional display name (defaults to AgentCard.name) */
+  name?: string;
+}
+
+/**
+ * Response for successful guild registration
+ */
+export interface GuildRegisterResponse {
+  /** Registered agent ID */
+  agent_id: string;
+  /** Bearer token for subsequent API calls */
+  token: string;
+  /** Confirmed display name */
+  name: string;
+  /** Token expiration (ISO8601, optional) */
+  expires_at?: string;
+}
+
+/**
+ * Result of guild registration
+ */
+export interface GuildRegisterResult {
+  ok: boolean;
+  response?: GuildRegisterResponse;
+  error?: string;
+  statusCode?: number;
+}
+
+/**
+ * Stored token entry
+ */
+interface TokenEntry {
+  agentId: string;
+  tokenHash: string;
+  name: string;
+  createdAt: string;
+  expiresAt?: string;
+}
+
+// ============================================================================
+// Token Management
+// ============================================================================
+
+/**
+ * In-memory token store for registered agents
+ * Note: This is lost on server restart. For production, consider persisting to DB.
+ */
+const guildTokens = new Map<string, TokenEntry>();
+
+/**
+ * Secret for signing tokens (should be set via environment variable)
+ */
+const GUILD_TOKEN_SECRET = process.env.GUILD_TOKEN_SECRET || 'proofguild-dev-secret';
+
+/**
+ * Generate a random token
+ */
+function generateToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Hash a token for storage
+ */
+function hashToken(token: string): string {
+  return createHmac('sha256', GUILD_TOKEN_SECRET)
+    .update(token)
+    .digest('hex');
+}
+
+/**
+ * Validate a token and return the associated agent ID
+ */
+export function validateGuildToken(token: string): string | null {
+  const tokenHash = hashToken(token);
+  for (const [agentId, entry] of guildTokens) {
+    if (entry.tokenHash === tokenHash) {
+      // Check expiration
+      if (entry.expiresAt && new Date(entry.expiresAt) < new Date()) {
+        guildTokens.delete(agentId);
+        return null;
+      }
+      return agentId;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get all registered guild tokens (for debugging)
+ */
+export function getGuildTokenCount(): number {
+  return guildTokens.size;
+}
+
+// ============================================================================
+// Rate Limiting
+// ============================================================================
+
+/**
+ * Simple in-memory rate limiter
+ */
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 10;
+
+/**
+ * Check if rate limit is exceeded
+ */
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+
+  if (!entry || entry.resetAt < now) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
+  }
+
+  entry.count++;
+  return entry.count > RATE_LIMIT_MAX_REQUESTS;
+}
+
+// ============================================================================
+// Registration Logic
+// ============================================================================
+
+export interface RegisterAgentOptions {
+  /** Targets store instance */
+  targetsStore: TargetsStore;
+  /** Audit logger for event emission */
+  auditLogger: AuditLogger;
+  /** Client IP for rate limiting */
+  clientIp: string;
+  /** Base event options */
+  baseOptions: Omit<ProofCommEventBaseOptions, 'target'>;
+  /** Allow local URLs (development only) */
+  allowLocal?: boolean;
+}
+
+/**
+ * Register an external agent with the Guild
+ *
+ * Flow:
+ * 1. Rate limit check
+ * 2. Fetch AgentCard from URL
+ * 3. Register agent in targets store
+ * 4. Generate and store token
+ * 5. Emit 'registered' event
+ * 6. Return token to agent
+ */
+export async function registerGuildAgent(
+  request: GuildRegisterRequest,
+  options: RegisterAgentOptions
+): Promise<GuildRegisterResult> {
+  const { targetsStore, auditLogger, clientIp, baseOptions, allowLocal } = options;
+
+  // Rate limit check
+  if (isRateLimited(clientIp)) {
+    return {
+      ok: false,
+      error: 'Rate limit exceeded. Try again later.',
+      statusCode: 429,
+    };
+  }
+
+  // Validate URL
+  if (!request.url || typeof request.url !== 'string') {
+    return {
+      ok: false,
+      error: 'Missing required field: url',
+      statusCode: 400,
+    };
+  }
+
+  // Normalize URL
+  const url = request.url.trim();
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    return {
+      ok: false,
+      error: 'Invalid URL: must start with http:// or https://',
+      statusCode: 400,
+    };
+  }
+
+  // Fetch AgentCard
+  const cardResult: FetchAgentCardResult = await fetchAgentCard(url, {
+    allowLocal,
+    timeout: 10_000,
+  });
+
+  if (!cardResult.ok || !cardResult.agentCard) {
+    return {
+      ok: false,
+      error: cardResult.error || 'Failed to fetch AgentCard',
+      statusCode: 422,
+    };
+  }
+
+  const agentCard = cardResult.agentCard;
+  const agentName = request.name || agentCard.name;
+
+  // Check if agent is already registered (by URL)
+  const existingTargets = targetsStore.list({ type: 'agent' });
+  for (const target of existingTargets) {
+    const config = target.config as { url?: string } | undefined;
+    if (config?.url === url) {
+      return {
+        ok: false,
+        error: 'Agent already registered with this URL',
+        statusCode: 409,
+      };
+    }
+  }
+
+  // Register agent in targets store
+  const agentId = ulid();
+  let target: TargetWithConfig;
+  try {
+    target = targetsStore.add({
+      type: 'agent',
+      protocol: 'a2a',
+      name: agentName,
+      enabled: true,
+      config: {
+        schema_version: 1,
+        url,
+        source: 'guild_register',
+        registered_at: new Date().toISOString(),
+      },
+    }, { id: agentId });
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Failed to register agent: ${err instanceof Error ? err.message : 'Unknown error'}`,
+      statusCode: 500,
+    };
+  }
+
+  // Generate token
+  const token = generateToken();
+  const tokenHash = hashToken(token);
+  const now = new Date().toISOString();
+
+  // Store token
+  guildTokens.set(agentId, {
+    agentId,
+    tokenHash,
+    name: agentName,
+    createdAt: now,
+    // No expiration for MVP
+  });
+
+  // Emit 'registered' event
+  emitSpaceEvent(
+    auditLogger,
+    'registered',
+    {
+      agent_id: agentId,
+      agent_name: agentName,
+    },
+    {
+      ...baseOptions,
+      target: agentId,
+    }
+  );
+
+  return {
+    ok: true,
+    response: {
+      agent_id: agentId,
+      token,
+      name: agentName,
+    },
+  };
+}
+
+/**
+ * Clean up expired tokens and old rate limit entries
+ */
+export function cleanupGuildTokens(): void {
+  const now = Date.now();
+
+  // Clean up expired tokens
+  for (const [agentId, entry] of guildTokens) {
+    if (entry.expiresAt && new Date(entry.expiresAt).getTime() < now) {
+      guildTokens.delete(agentId);
+    }
+  }
+
+  // Clean up old rate limit entries
+  for (const [ip, entry] of rateLimitMap) {
+    if (entry.resetAt < now) {
+      rateLimitMap.delete(ip);
+    }
+  }
+}

--- a/src/proofportal/__tests__/guild.test.ts
+++ b/src/proofportal/__tests__/guild.test.ts
@@ -1,0 +1,666 @@
+/**
+ * ProofPortal - Guild tests
+ * Phase 5: ProofGuild
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcLevel,
+  getVisualState,
+  getMembershipStatus,
+  getGuildRole,
+  toGuildMember,
+  deriveGuildState,
+  createInitialState,
+  applyEvent,
+  SPEAKING_THRESHOLD_MS,
+  ACTIVE_THRESHOLD_MS,
+  type AgentState,
+  type SpaceState,
+  type PortalSseEvent,
+} from '../types.js';
+
+describe('ProofGuild - Level Calculation', () => {
+  describe('calcLevel', () => {
+    it('should return level 1 for 0 XP', () => {
+      expect(calcLevel(0)).toBe(1);
+    });
+
+    it('should return level 1 for 9 XP', () => {
+      expect(calcLevel(9)).toBe(1);
+    });
+
+    it('should return level 2 for 10 XP', () => {
+      expect(calcLevel(10)).toBe(2);
+    });
+
+    it('should return level 2 for 39 XP', () => {
+      expect(calcLevel(39)).toBe(2);
+    });
+
+    it('should return level 3 for 40 XP', () => {
+      expect(calcLevel(40)).toBe(3);
+    });
+
+    it('should return level 4 for 90 XP', () => {
+      expect(calcLevel(90)).toBe(4);
+    });
+
+    it('should return level 5 for 160 XP', () => {
+      expect(calcLevel(160)).toBe(5);
+    });
+
+    it('should handle large XP values', () => {
+      expect(calcLevel(10000)).toBe(32);
+    });
+  });
+});
+
+describe('ProofGuild - Visual State', () => {
+  describe('getVisualState', () => {
+    it('should return speaking if message within threshold', () => {
+      const now = Date.now();
+      const lastMessageAt = now - 5000; // 5 seconds ago
+      const lastSeenAt = now - 1000;
+
+      expect(getVisualState(lastMessageAt, lastSeenAt, now)).toBe('speaking');
+    });
+
+    it('should return speaking at exact threshold', () => {
+      const now = Date.now();
+      const lastMessageAt = now - SPEAKING_THRESHOLD_MS + 1;
+      const lastSeenAt = now - 1000;
+
+      expect(getVisualState(lastMessageAt, lastSeenAt, now)).toBe('speaking');
+    });
+
+    it('should return active if no recent message but recent event', () => {
+      const now = Date.now();
+      const lastMessageAt = now - 30000; // 30 seconds ago
+      const lastSeenAt = now - 5000;
+
+      expect(getVisualState(lastMessageAt, lastSeenAt, now)).toBe('active');
+    });
+
+    it('should return active with no message but recent event', () => {
+      const now = Date.now();
+      const lastSeenAt = now - 30000;
+
+      expect(getVisualState(undefined, lastSeenAt, now)).toBe('active');
+    });
+
+    it('should return idle if no recent activity', () => {
+      const now = Date.now();
+      const lastMessageAt = now - 120000; // 2 minutes ago
+      const lastSeenAt = now - 90000;
+
+      expect(getVisualState(lastMessageAt, lastSeenAt, now)).toBe('idle');
+    });
+
+    it('should return idle at exact active threshold', () => {
+      const now = Date.now();
+      const lastSeenAt = now - ACTIVE_THRESHOLD_MS;
+
+      expect(getVisualState(undefined, lastSeenAt, now)).toBe('idle');
+    });
+  });
+});
+
+describe('ProofGuild - Membership Status', () => {
+  describe('getMembershipStatus', () => {
+    it('should return active if recent event', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 5,
+        lastSeenAt: now - 30000,
+        experience: 0,
+      };
+
+      expect(getMembershipStatus(agent, now)).toBe('active');
+    });
+
+    it('should return joined if has space membership but not active', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 5,
+        lastSeenAt: now - 120000, // 2 minutes ago
+        experience: 0,
+      };
+
+      expect(getMembershipStatus(agent, now)).toBe('joined');
+    });
+
+    it('should return candidate if no space membership and not active', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(),
+        eventCount: 1,
+        lastSeenAt: now - 120000,
+        experience: 0,
+      };
+
+      expect(getMembershipStatus(agent, now)).toBe('candidate');
+    });
+  });
+});
+
+describe('ProofGuild - Guild Role', () => {
+  describe('getGuildRole', () => {
+    it('should return visitor if no space membership', () => {
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(),
+        eventCount: 0,
+        lastSeenAt: Date.now(),
+        experience: 0,
+      };
+      const spaces = new Map<string, SpaceState>();
+
+      expect(getGuildRole(agent, spaces)).toBe('visitor');
+    });
+
+    it('should return member if has space membership', () => {
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 1,
+        lastSeenAt: Date.now(),
+        experience: 0,
+      };
+      const spaces = new Map<string, SpaceState>();
+
+      expect(getGuildRole(agent, spaces)).toBe('member');
+    });
+  });
+});
+
+describe('ProofGuild - Guild Member Derivation', () => {
+  describe('toGuildMember', () => {
+    it('should derive guild member from agent state', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'test-agent-123',
+        traceIds: new Set(['trace-1']),
+        spaceIds: new Set(['space-1']),
+        eventCount: 10,
+        lastSeenAt: now - 5000,
+        name: 'TestBot',
+        experience: 45,
+        currentSpaceId: 'space-1',
+        currentSpaceName: 'Test Room',
+        lastMessagePreview: 'Hello world',
+        lastMessageAt: now - 2000,
+      };
+      const spaces = new Map<string, SpaceState>();
+
+      const member = toGuildMember(agent, spaces, now);
+
+      expect(member.agentId).toBe('test-agent-123');
+      expect(member.name).toBe('TestBot');
+      expect(member.level).toBe(3); // sqrt(45/10) + 1 = 3
+      expect(member.experience).toBe(45);
+      expect(member.role).toBe('member');
+      expect(member.membershipStatus).toBe('active');
+      expect(member.visualState).toBe('speaking');
+      expect(member.currentSpaceId).toBe('space-1');
+      expect(member.lastMessagePreview).toBe('Hello world');
+      expect(member.eventCount).toBe(10);
+    });
+
+    it('should use agentId as name fallback', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'agent-abc-123',
+        traceIds: new Set(),
+        spaceIds: new Set(),
+        eventCount: 1,
+        lastSeenAt: now - 1000,
+        experience: 0,
+      };
+      const spaces = new Map<string, SpaceState>();
+
+      const member = toGuildMember(agent, spaces, now);
+
+      expect(member.name).toBe('agent-abc-123');
+    });
+  });
+});
+
+describe('ProofGuild - Guild State Derivation', () => {
+  describe('deriveGuildState', () => {
+    it('should derive empty guild state from empty portal state', () => {
+      const state = createInitialState();
+      const now = Date.now();
+
+      const guild = deriveGuildState(state, now);
+
+      expect(guild.members.size).toBe(0);
+      expect(guild.rooms.size).toBe(0);
+    });
+
+    it('should derive guild members from agents', () => {
+      const state = createInitialState();
+      const now = Date.now();
+
+      state.agents.set('agent-1', {
+        agentId: 'agent-1',
+        name: 'Bot1',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 5,
+        lastSeenAt: now - 1000,
+        experience: 20,
+        currentSpaceId: 'space-1',
+      });
+
+      const guild = deriveGuildState(state, now);
+
+      expect(guild.members.size).toBe(1);
+      expect(guild.members.get('agent-1')?.name).toBe('Bot1');
+    });
+
+    it('should derive rooms from spaces with members', () => {
+      const state = createInitialState();
+      const now = Date.now();
+
+      state.spaces.set('space-1', {
+        spaceId: 'space-1',
+        spaceName: 'Main Hall',
+        members: new Set(['agent-1']),
+        events: [],
+        messageCount: 5,
+        lastActivityAt: now,
+      });
+
+      state.agents.set('agent-1', {
+        agentId: 'agent-1',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 5,
+        lastSeenAt: now - 1000,
+        experience: 10,
+        currentSpaceId: 'space-1',
+      });
+
+      const guild = deriveGuildState(state, now);
+
+      expect(guild.rooms.size).toBe(1);
+      const room = guild.rooms.get('space-1');
+      expect(room?.spaceName).toBe('Main Hall');
+      expect(room?.memberIds).toContain('agent-1');
+    });
+  });
+});
+
+describe('ProofGuild - XP Calculation via Events', () => {
+  it('should award XP for join event', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.experience).toBe(2);
+  });
+
+  it('should award XP for message event', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        message_preview: 'Hello',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.experience).toBe(5);
+  });
+
+  it('should award XP for skill match event', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_skill',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'match',
+        agent_id: 'agent-1',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.experience).toBe(10);
+  });
+
+  it('should accumulate XP across multiple events', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // Join event
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Message event
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Another message
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 2000,
+      request_id: 'req-3',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.experience).toBe(2 + 5 + 5); // join + 2 messages
+  });
+});
+
+describe('ProofGuild - currentSpaceId Tracking', () => {
+  it('should set currentSpaceId on join', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        space_name: 'Main Room',
+        agent_id: 'agent-1',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.currentSpaceId).toBe('space-1');
+    expect(agent?.currentSpaceName).toBe('Main Room');
+  });
+
+  it('should update currentSpaceId on message', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // Join space-1
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Message in space-2
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'message',
+        space_id: 'space-2',
+        space_name: 'Side Room',
+        agent_id: 'agent-1',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.currentSpaceId).toBe('space-2');
+    expect(agent?.currentSpaceName).toBe('Side Room');
+  });
+
+  it('should clear currentSpaceId on leave from current space', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // Join
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Leave
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'left',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.currentSpaceId).toBeUndefined();
+    expect(agent?.currentSpaceName).toBeUndefined();
+  });
+
+  it('should not clear currentSpaceId when leaving different space', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // Join space-1
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Leave space-2 (different space)
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'left',
+        space_id: 'space-2',
+        agent_id: 'agent-1',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.currentSpaceId).toBe('space-1');
+  });
+});
+
+describe('ProofGuild - Agent Name Tracking', () => {
+  it('should extract agent_name from metadata', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        agent_name: 'CoolBot',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.name).toBe('CoolBot');
+  });
+
+  it('should update name if new agent_name provided', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // First event with name
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        agent_id: 'agent-1',
+        agent_name: 'OldName',
+      },
+    });
+
+    // Second event with new name
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'message',
+        agent_id: 'agent-1',
+        agent_name: 'NewName',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.name).toBe('NewName');
+  });
+});
+
+describe('ProofGuild - Message Preview Tracking', () => {
+  it('should truncate message preview to 40 chars', () => {
+    const state = createInitialState();
+    const longMessage = 'This is a very long message that exceeds 40 characters and should be truncated';
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        message_preview: longMessage,
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.lastMessagePreview?.length).toBeLessThanOrEqual(40);
+  });
+
+  it('should keep short messages intact', () => {
+    const state = createInitialState();
+    const shortMessage = 'Hello!';
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        message_preview: shortMessage,
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.lastMessagePreview).toBe('Hello!');
+  });
+
+  it('should track lastMessageAt timestamp', () => {
+    const state = createInitialState();
+    const now = Date.now();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        message_preview: 'Test',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.lastMessageAt).toBe(now);
+  });
+});

--- a/src/proofportal/__tests__/templates.test.ts
+++ b/src/proofportal/__tests__/templates.test.ts
@@ -8,7 +8,7 @@ import { renderDashboard } from '../templates/dashboard.js';
 import { escapeHtml, renderLayout } from '../templates/layout.js';
 import {
   createInitialState,
-  updateState,
+  applyEvent,
   toDisplayEvent,
   type PortalSseEvent,
 } from '../types.js';
@@ -152,9 +152,9 @@ describe('ProofPortal state management', () => {
     });
   });
 
-  describe('updateState', () => {
+  describe('applyEvent', () => {
     it('should update thread state', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -167,14 +167,14 @@ describe('ProofPortal state management', () => {
         },
       };
 
-      state = updateState(state, event);
+      applyEvent(state, event);
 
       expect(state.threads.size).toBe(1);
       expect(state.threads.get('trace-1')?.participants.has('agent-1')).toBe(true);
     });
 
     it('should update space state on join', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -187,17 +187,17 @@ describe('ProofPortal state management', () => {
         },
       };
 
-      state = updateState(state, event);
+      applyEvent(state, event);
 
       expect(state.spaces.size).toBe(1);
       expect(state.spaces.get('space-1')?.members.has('agent-1')).toBe(true);
     });
 
     it('should update space state on leave', () => {
-      let state = createInitialState();
+      const state = createInitialState();
 
       // First join
-      state = updateState(state, {
+      applyEvent(state, {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
         ts: 1704067200000,
@@ -210,7 +210,7 @@ describe('ProofPortal state management', () => {
       });
 
       // Then leave
-      state = updateState(state, {
+      applyEvent(state, {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
         ts: 1704067201000,
@@ -226,7 +226,7 @@ describe('ProofPortal state management', () => {
     });
 
     it('should increment message count', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -238,14 +238,14 @@ describe('ProofPortal state management', () => {
         },
       };
 
-      state = updateState(state, event);
-      state = updateState(state, { ...event, request_id: 'req-2' });
+      applyEvent(state, event);
+      applyEvent(state, { ...event, request_id: 'req-2' });
 
       expect(state.spaces.get('space-1')?.messageCount).toBe(2);
     });
 
     it('should update agent state', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -259,7 +259,7 @@ describe('ProofPortal state management', () => {
         },
       };
 
-      state = updateState(state, event);
+      applyEvent(state, event);
 
       expect(state.agents.size).toBe(1);
       const agent = state.agents.get('agent-1');
@@ -269,7 +269,7 @@ describe('ProofPortal state management', () => {
     });
 
     it('should increment global event count', () => {
-      let state = createInitialState();
+      const state = createInitialState();
       const event: PortalSseEvent = {
         event_kind: 'proofcomm_space',
         client_id: 'client-1',
@@ -278,11 +278,60 @@ describe('ProofPortal state management', () => {
         metadata: { action: 'message' },
       };
 
-      state = updateState(state, event);
-      state = updateState(state, { ...event, request_id: 'req-2' });
-      state = updateState(state, { ...event, request_id: 'req-3' });
+      applyEvent(state, event);
+      applyEvent(state, { ...event, request_id: 'req-2' });
+      applyEvent(state, { ...event, request_id: 'req-3' });
 
       expect(state.eventCount).toBe(3);
+    });
+  });
+});
+
+describe('ProofPortal routes', () => {
+  // Note: Full route testing requires Fastify server setup.
+  // These tests verify the route registration function exists and has correct exports.
+
+  describe('registerPortalRoutes', () => {
+    it('should be exported from index', async () => {
+      const { registerPortalRoutes } = await import('../index.js');
+      expect(typeof registerPortalRoutes).toBe('function');
+    });
+  });
+
+  describe('PortalRoutesOptions', () => {
+    it('should allow basePath option', async () => {
+      const { registerPortalRoutes } = await import('../routes.js');
+
+      // Mock Fastify instance
+      const routes: Array<{ method: string; path: string }> = [];
+      const mockFastify = {
+        get: (path: string, _handler: unknown) => {
+          routes.push({ method: 'GET', path });
+        },
+      };
+
+      registerPortalRoutes(mockFastify as never, { basePath: '/custom-portal' });
+
+      expect(routes).toContainEqual({ method: 'GET', path: '/custom-portal' });
+      expect(routes).toContainEqual({ method: 'GET', path: '/custom-portal/' });
+      expect(routes).toContainEqual({ method: 'GET', path: '/custom-portal/api/status' });
+    });
+
+    it('should use default basePath /portal', async () => {
+      const { registerPortalRoutes } = await import('../routes.js');
+
+      const routes: Array<{ method: string; path: string }> = [];
+      const mockFastify = {
+        get: (path: string, _handler: unknown) => {
+          routes.push({ method: 'GET', path });
+        },
+      };
+
+      registerPortalRoutes(mockFastify as never);
+
+      expect(routes).toContainEqual({ method: 'GET', path: '/portal' });
+      expect(routes).toContainEqual({ method: 'GET', path: '/portal/' });
+      expect(routes).toContainEqual({ method: 'GET', path: '/portal/api/status' });
     });
   });
 });

--- a/src/proofportal/__tests__/templates.test.ts
+++ b/src/proofportal/__tests__/templates.test.ts
@@ -1,0 +1,288 @@
+/**
+ * ProofPortal - Template tests
+ * Phase 4: ProofPortal MVP
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderDashboard } from '../templates/dashboard.js';
+import { escapeHtml, renderLayout } from '../templates/layout.js';
+import {
+  createInitialState,
+  updateState,
+  toDisplayEvent,
+  type PortalSseEvent,
+} from '../types.js';
+
+describe('ProofPortal templates', () => {
+  describe('escapeHtml', () => {
+    it('should escape HTML special characters', () => {
+      expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+        '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+      );
+    });
+
+    it('should escape ampersand', () => {
+      expect(escapeHtml('foo & bar')).toBe('foo &amp; bar');
+    });
+
+    it('should escape single quotes', () => {
+      expect(escapeHtml("it's")).toBe('it&#039;s');
+    });
+  });
+
+  describe('renderLayout', () => {
+    it('should render complete HTML document', () => {
+      const html = renderLayout({
+        title: 'Test Portal',
+        content: '<div>Test content</div>',
+      });
+
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('<title>Test Portal</title>');
+      expect(html).toContain('<div>Test content</div>');
+      expect(html).toContain('data-app="portal"');
+    });
+
+    it('should include connection status element', () => {
+      const html = renderLayout({
+        title: 'Test',
+        content: '',
+      });
+
+      expect(html).toContain('id="connectionStatus"');
+      expect(html).toContain('connection-status');
+    });
+
+    it('should include scripts when provided', () => {
+      const html = renderLayout({
+        title: 'Test',
+        content: '',
+        scripts: 'console.log("test");',
+      });
+
+      expect(html).toContain('console.log("test");');
+    });
+  });
+
+  describe('renderDashboard', () => {
+    it('should render dashboard with three panels', () => {
+      const html = renderDashboard({
+        generatedAt: '2024-01-01T00:00:00Z',
+      });
+
+      expect(html).toContain('id="agentList"');
+      expect(html).toContain('id="threadList"');
+      expect(html).toContain('id="spaceList"');
+    });
+
+    it('should include SSE client script', () => {
+      const html = renderDashboard({
+        generatedAt: '2024-01-01T00:00:00Z',
+      });
+
+      expect(html).toContain('EventSource');
+      expect(html).toContain('proofcomm_space');
+    });
+
+    it('should show generated timestamp', () => {
+      const html = renderDashboard({
+        generatedAt: '2024-01-01T00:00:00Z',
+      });
+
+      expect(html).toContain('2024-01-01T00:00:00Z');
+    });
+  });
+});
+
+describe('ProofPortal state management', () => {
+  describe('createInitialState', () => {
+    it('should create empty state', () => {
+      const state = createInitialState();
+
+      expect(state.threads.size).toBe(0);
+      expect(state.spaces.size).toBe(0);
+      expect(state.agents.size).toBe(0);
+      expect(state.connected).toBe(false);
+      expect(state.eventCount).toBe(0);
+    });
+  });
+
+  describe('toDisplayEvent', () => {
+    it('should convert SSE event to display format', () => {
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        trace_id: 'trace-1',
+        metadata: {
+          action: 'message',
+          space_id: 'space-1',
+          space_name: 'Test Space',
+          agent_id: 'agent-1',
+          message_preview: 'Hello world',
+        },
+      };
+
+      const display = toDisplayEvent(event);
+
+      expect(display.id).toBe('req-1');
+      expect(display.eventKind).toBe('proofcomm_space');
+      expect(display.action).toBe('message');
+      expect(display.traceId).toBe('trace-1');
+      expect(display.spaceId).toBe('space-1');
+      expect(display.spaceName).toBe('Test Space');
+      expect(display.agentId).toBe('agent-1');
+      expect(display.preview).toBe('Hello world');
+    });
+
+    it('should handle missing metadata', () => {
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+      };
+
+      const display = toDisplayEvent(event);
+
+      expect(display.traceId).toBeNull();
+      expect(display.spaceId).toBeNull();
+      expect(display.agentId).toBeNull();
+    });
+  });
+
+  describe('updateState', () => {
+    it('should update thread state', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        trace_id: 'trace-1',
+        metadata: {
+          action: 'message',
+          agent_id: 'agent-1',
+        },
+      };
+
+      state = updateState(state, event);
+
+      expect(state.threads.size).toBe(1);
+      expect(state.threads.get('trace-1')?.participants.has('agent-1')).toBe(true);
+    });
+
+    it('should update space state on join', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        metadata: {
+          action: 'joined',
+          space_id: 'space-1',
+          agent_id: 'agent-1',
+        },
+      };
+
+      state = updateState(state, event);
+
+      expect(state.spaces.size).toBe(1);
+      expect(state.spaces.get('space-1')?.members.has('agent-1')).toBe(true);
+    });
+
+    it('should update space state on leave', () => {
+      let state = createInitialState();
+
+      // First join
+      state = updateState(state, {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        metadata: {
+          action: 'joined',
+          space_id: 'space-1',
+          agent_id: 'agent-1',
+        },
+      });
+
+      // Then leave
+      state = updateState(state, {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067201000,
+        request_id: 'req-2',
+        metadata: {
+          action: 'left',
+          space_id: 'space-1',
+          agent_id: 'agent-1',
+        },
+      });
+
+      expect(state.spaces.get('space-1')?.members.has('agent-1')).toBe(false);
+    });
+
+    it('should increment message count', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        metadata: {
+          action: 'message',
+          space_id: 'space-1',
+        },
+      };
+
+      state = updateState(state, event);
+      state = updateState(state, { ...event, request_id: 'req-2' });
+
+      expect(state.spaces.get('space-1')?.messageCount).toBe(2);
+    });
+
+    it('should update agent state', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        trace_id: 'trace-1',
+        metadata: {
+          action: 'message',
+          space_id: 'space-1',
+          agent_id: 'agent-1',
+        },
+      };
+
+      state = updateState(state, event);
+
+      expect(state.agents.size).toBe(1);
+      const agent = state.agents.get('agent-1');
+      expect(agent?.eventCount).toBe(1);
+      expect(agent?.traceIds.has('trace-1')).toBe(true);
+      expect(agent?.spaceIds.has('space-1')).toBe(true);
+    });
+
+    it('should increment global event count', () => {
+      let state = createInitialState();
+      const event: PortalSseEvent = {
+        event_kind: 'proofcomm_space',
+        client_id: 'client-1',
+        ts: 1704067200000,
+        request_id: 'req-1',
+        metadata: { action: 'message' },
+      };
+
+      state = updateState(state, event);
+      state = updateState(state, { ...event, request_id: 'req-2' });
+      state = updateState(state, { ...event, request_id: 'req-3' });
+
+      expect(state.eventCount).toBe(3);
+    });
+  });
+});

--- a/src/proofportal/index.ts
+++ b/src/proofportal/index.ts
@@ -1,0 +1,39 @@
+/**
+ * ProofPortal - Agent Communication Visualization
+ * Phase 4: ProofPortal MVP
+ *
+ * Real-time visualization UI for ProofComm agent communication.
+ * Consumes SSE events and provides read-only monitoring.
+ *
+ * Usage:
+ *   import { registerPortalRoutes } from './proofportal/index.js';
+ *   registerPortalRoutes(fastify);
+ *
+ * Access:
+ *   http://localhost:8080/portal
+ */
+
+// Route registration
+export { registerPortalRoutes, type PortalRoutesOptions } from './routes.js';
+
+// Types
+export {
+  type PortalState,
+  type ThreadState,
+  type SpaceState,
+  type AgentState,
+  type PortalEventDisplay,
+  type PortalSseEvent,
+  type ProofCommMetadata,
+  type ProofCommAction,
+  PROOFCOMM_EVENT_KINDS,
+  createInitialState,
+  toDisplayEvent,
+  updateState,
+} from './types.js';
+
+// Templates
+export { renderDashboard, renderLayout, escapeHtml } from './templates/index.js';
+
+// SSE Client script
+export { getSseClientScript } from './sse-client.js';

--- a/src/proofportal/index.ts
+++ b/src/proofportal/index.ts
@@ -29,7 +29,7 @@ export {
   PROOFCOMM_EVENT_KINDS,
   createInitialState,
   toDisplayEvent,
-  updateState,
+  applyEvent,
 } from './types.js';
 
 // Templates

--- a/src/proofportal/index.ts
+++ b/src/proofportal/index.ts
@@ -1,9 +1,10 @@
 /**
  * ProofPortal - Agent Communication Visualization
- * Phase 4: ProofPortal MVP
+ * Phase 5: ProofGuild
  *
  * Real-time visualization UI for ProofComm agent communication.
  * Consumes SSE events and provides read-only monitoring.
+ * Displays agents as Guild members with roles, levels, and visual states.
  *
  * Usage:
  *   import { registerPortalRoutes } from './proofportal/index.js';
@@ -18,6 +19,7 @@ export { registerPortalRoutes, type PortalRoutesOptions } from './routes.js';
 
 // Types
 export {
+  // Portal types
   type PortalState,
   type ThreadState,
   type SpaceState,
@@ -30,6 +32,22 @@ export {
   createInitialState,
   toDisplayEvent,
   applyEvent,
+  // Guild types (Phase 5)
+  type GuildRole,
+  type GuildVisualState,
+  type GuildMembershipStatus,
+  type GuildMember,
+  type GuildSpaceRoom,
+  type GuildState,
+  // Guild helpers
+  calcLevel,
+  getVisualState,
+  getMembershipStatus,
+  getGuildRole,
+  toGuildMember,
+  deriveGuildState,
+  SPEAKING_THRESHOLD_MS,
+  ACTIVE_THRESHOLD_MS,
 } from './types.js';
 
 // Templates

--- a/src/proofportal/routes.ts
+++ b/src/proofportal/routes.ts
@@ -1,0 +1,58 @@
+/**
+ * ProofPortal - Fastify route registration
+ * Phase 4: ProofPortal MVP
+ *
+ * Registers portal routes on the Gateway Fastify server.
+ * Portal is read-only and consumes SSE events from /events/stream
+ */
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { renderDashboard } from './templates/index.js';
+
+/**
+ * Options for registering portal routes
+ */
+export interface PortalRoutesOptions {
+  /** Base path for portal routes (default: '/portal') */
+  basePath?: string;
+}
+
+/**
+ * Register ProofPortal routes on a Fastify instance
+ *
+ * Routes:
+ * - GET /portal - Main dashboard (HTML)
+ * - GET /portal/api/status - Portal status (JSON)
+ */
+export function registerPortalRoutes(
+  fastify: FastifyInstance,
+  options: PortalRoutesOptions = {}
+): void {
+  const basePath = options.basePath ?? '/portal';
+
+  // GET /portal - Main dashboard
+  fastify.get(basePath, async (_request: FastifyRequest, reply: FastifyReply) => {
+    const html = renderDashboard({
+      generatedAt: new Date().toISOString(),
+    });
+
+    return reply
+      .header('Content-Type', 'text/html; charset=utf-8')
+      .send(html);
+  });
+
+  // GET /portal/ - Also handle trailing slash
+  fastify.get(`${basePath}/`, async (_request: FastifyRequest, reply: FastifyReply) => {
+    return reply.redirect(basePath);
+  });
+
+  // GET /portal/api/status - Portal status (JSON)
+  fastify.get(`${basePath}/api/status`, async (_request: FastifyRequest, _reply: FastifyReply) => {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      version: '4.0.0',
+      mode: 'sse',
+    };
+  });
+}

--- a/src/proofportal/routes.ts
+++ b/src/proofportal/routes.ts
@@ -4,6 +4,11 @@
  *
  * Registers portal routes on the Gateway Fastify server.
  * Portal is read-only and consumes SSE events from /events/stream
+ *
+ * Authentication:
+ * - All portal routes require Bearer token authentication (via Gateway auth middleware)
+ * - No additional permission check is required as portal is read-only visualization
+ * - SSE events are already filtered by the /events/stream endpoint permissions
  */
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
@@ -23,12 +28,24 @@ export interface PortalRoutesOptions {
  * Routes:
  * - GET /portal - Main dashboard (HTML)
  * - GET /portal/api/status - Portal status (JSON)
+ *
+ * Security:
+ * - Requires Bearer token authentication (handled by Gateway preHandler)
+ * - Cache-Control: no-store prevents caching of dynamic dashboard
+ * - Content-Security-Policy restricts script execution
  */
 export function registerPortalRoutes(
   fastify: FastifyInstance,
   options: PortalRoutesOptions = {}
 ): void {
   const basePath = options.basePath ?? '/portal';
+
+  // Security headers for portal routes
+  const securityHeaders = {
+    'Cache-Control': 'no-store',
+    // Allow inline scripts (required for SSE client) but restrict other sources
+    'Content-Security-Policy': "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'",
+  };
 
   // GET /portal - Main dashboard
   fastify.get(basePath, async (_request: FastifyRequest, reply: FastifyReply) => {
@@ -38,6 +55,7 @@ export function registerPortalRoutes(
 
     return reply
       .header('Content-Type', 'text/html; charset=utf-8')
+      .headers(securityHeaders)
       .send(html);
   });
 
@@ -47,12 +65,14 @@ export function registerPortalRoutes(
   });
 
   // GET /portal/api/status - Portal status (JSON)
-  fastify.get(`${basePath}/api/status`, async (_request: FastifyRequest, _reply: FastifyReply) => {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      version: '4.0.0',
-      mode: 'sse',
-    };
+  fastify.get(`${basePath}/api/status`, async (_request: FastifyRequest, reply: FastifyReply) => {
+    return reply
+      .header('Cache-Control', 'no-store')
+      .send({
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+        version: '4.0.0',
+        mode: 'sse',
+      });
   });
 }

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -4,10 +4,22 @@
  *
  * This module generates inline JavaScript for browser-side SSE consumption.
  * The generated code runs in the browser to receive real-time events from Gateway.
+ *
+ * Note: Utility functions (formatTime, formatRelativeTime, truncateId, etc.)
+ * are intentionally duplicated here from the server-side component files.
+ * This duplication is architecturally unavoidable because:
+ * - Server-side: TypeScript modules used for SSR
+ * - Browser-side: Inline JavaScript with no module system
+ * The functions must be kept in sync manually.
  */
 
 /**
  * Get browser-side SSE client script
+ *
+ * WARNING: The returned script is embedded directly in the HTML page.
+ * Only trusted, hardcoded content should be used. Never pass user-controlled
+ * data to this function as it would create an XSS vulnerability.
+ *
  * This is embedded as inline JavaScript in the HTML page.
  */
 export function getSseClientScript(): string {
@@ -23,6 +35,11 @@ export function getSseClientScript(): string {
     'proofcomm_route'
   ];
 
+  // State size limits (LRU eviction when exceeded)
+  const MAX_THREADS = 100;
+  const MAX_SPACES = 50;
+  const MAX_AGENTS = 100;
+
   // State
   const state = {
     threads: new Map(),
@@ -37,6 +54,24 @@ export function getSseClientScript(): string {
   let reconnectAttempts = 0;
   const MAX_RECONNECT_ATTEMPTS = 10;
   const RECONNECT_DELAY = 3000;
+
+  /**
+   * Evict oldest entries from a Map to maintain size limit (LRU)
+   * Entries are evicted based on lastActivityAt or lastSeenAt field
+   */
+  function evictOldest(map, maxSize, timeField) {
+    if (map.size <= maxSize) return;
+
+    // Convert to array and sort by time (oldest first)
+    const entries = Array.from(map.entries())
+      .sort((a, b) => (a[1][timeField] || 0) - (b[1][timeField] || 0));
+
+    // Remove oldest entries until we're under the limit
+    const toRemove = map.size - maxSize;
+    for (let i = 0; i < toRemove; i++) {
+      map.delete(entries[i][0]);
+    }
+  }
 
   // DOM elements
   const connectionStatus = document.getElementById('connectionStatus');
@@ -167,6 +202,11 @@ export function getSseClientScript(): string {
       thread.lastActivityAt = now;
       if (agentId) thread.participants.add(agentId);
     }
+
+    // LRU eviction to prevent unbounded memory growth
+    evictOldest(state.agents, MAX_AGENTS, 'lastSeenAt');
+    evictOldest(state.spaces, MAX_SPACES, 'lastActivityAt');
+    evictOldest(state.threads, MAX_THREADS, 'lastActivityAt');
 
     // Update UI
     renderAgentList();

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -1,6 +1,6 @@
 /**
  * ProofPortal - SSE Client (Browser-side)
- * Phase 4: ProofPortal MVP
+ * Phase 5: ProofGuild
  *
  * This module generates inline JavaScript for browser-side SSE consumption.
  * The generated code runs in the browser to receive real-time events from Gateway.
@@ -11,6 +11,11 @@
  * - Server-side: TypeScript modules used for SSR
  * - Browser-side: Inline JavaScript with no module system
  * The functions must be kept in sync manually.
+ *
+ * Phase 5 additions:
+ * - Guild state tracking (name, XP, level, visualState)
+ * - currentSpaceId tracking for Room placement
+ * - Speaking/Active/Idle state calculation
  */
 
 /**
@@ -39,6 +44,20 @@ export function getSseClientScript(): string {
   const MAX_THREADS = 100;
   const MAX_SPACES = 50;
   const MAX_AGENTS = 100;
+
+  // Guild thresholds (Phase 5)
+  const SPEAKING_THRESHOLD_MS = 10000;  // 10 seconds for 'speaking' state
+  const ACTIVE_THRESHOLD_MS = 60000;    // 60 seconds for 'active' state
+
+  // XP values per action
+  const XP_VALUES = {
+    joined: 2,
+    message: 5,
+    match: 10,
+    context_updated: 8,
+    dispatched: 6,
+    registered: 3
+  };
 
   // State
   const state = {
@@ -80,6 +99,9 @@ export function getSseClientScript(): string {
   const agentListEl = document.getElementById('agentList');
   const threadListEl = document.getElementById('threadList');
   const spaceListEl = document.getElementById('spaceList');
+  // Guild DOM elements (Phase 5)
+  const guildPanelEl = document.getElementById('guildPanel');
+  const guildMapEl = document.getElementById('guildMap');
 
   /**
    * Update connection status display
@@ -128,6 +150,59 @@ export function getSseClientScript(): string {
       .replace(/"/g, '&quot;');
   }
 
+  // ============================================================================
+  // Guild Helper Functions (Phase 5)
+  // ============================================================================
+
+  /**
+   * Calculate level from XP
+   */
+  function calcLevel(xp) {
+    return Math.floor(Math.sqrt(xp / 10)) + 1;
+  }
+
+  /**
+   * Get visual state based on timestamps
+   */
+  function getVisualState(agent, now) {
+    if (agent.lastMessageAt && (now - agent.lastMessageAt) < SPEAKING_THRESHOLD_MS) {
+      return 'speaking';
+    }
+    if ((now - agent.lastSeenAt) < ACTIVE_THRESHOLD_MS) {
+      return 'active';
+    }
+    return 'idle';
+  }
+
+  /**
+   * Get membership status
+   */
+  function getMembershipStatus(agent, now) {
+    if ((now - agent.lastSeenAt) < ACTIVE_THRESHOLD_MS) {
+      return 'active';
+    }
+    if (agent.spaceIds.size > 0) {
+      return 'joined';
+    }
+    return 'candidate';
+  }
+
+  /**
+   * Get display name for agent
+   */
+  function getAgentDisplayName(agent) {
+    return agent.name || truncateId(agent.agentId, 12);
+  }
+
+  /**
+   * Truncate message preview for bubble display
+   */
+  function truncatePreview(str, maxLen) {
+    if (!str) return '';
+    if (str.length <= maxLen) return str;
+    return str.slice(0, maxLen - 1) + '…';
+  }
+
   /**
    * Process incoming SSE event
    */
@@ -150,7 +225,14 @@ export function getSseClientScript(): string {
           traceIds: new Set(),
           spaceIds: new Set(),
           eventCount: 0,
-          lastSeenAt: now
+          lastSeenAt: now,
+          // Guild fields (Phase 5)
+          name: null,
+          experience: 0,
+          lastMessagePreview: null,
+          lastMessageAt: null,
+          currentSpaceId: null,
+          currentSpaceName: null
         };
         state.agents.set(agentId, agent);
       }
@@ -158,6 +240,39 @@ export function getSseClientScript(): string {
       agent.lastSeenAt = now;
       if (traceId) agent.traceIds.add(traceId);
       if (spaceId) agent.spaceIds.add(spaceId);
+
+      // Guild updates (Phase 5)
+      // Extract agent_name from metadata
+      if (metadata.agent_name) {
+        agent.name = metadata.agent_name;
+      }
+
+      // Track currentSpaceId and XP based on action
+      const action = metadata.action;
+      if (action === 'joined' && spaceId) {
+        agent.currentSpaceId = spaceId;
+        agent.currentSpaceName = metadata.space_name || null;
+        agent.experience += XP_VALUES.joined || 0;
+      } else if (action === 'message' && spaceId) {
+        agent.currentSpaceId = spaceId;
+        agent.currentSpaceName = metadata.space_name || null;
+        agent.lastMessagePreview = truncatePreview(metadata.message_preview, 40);
+        agent.lastMessageAt = now;
+        agent.experience += XP_VALUES.message || 0;
+      } else if (action === 'left' && spaceId) {
+        if (agent.currentSpaceId === spaceId) {
+          agent.currentSpaceId = null;
+          agent.currentSpaceName = null;
+        }
+      } else if (action === 'match') {
+        agent.experience += XP_VALUES.match || 0;
+      } else if (action === 'context_updated') {
+        agent.experience += XP_VALUES.context_updated || 0;
+      } else if (action === 'dispatched') {
+        agent.experience += XP_VALUES.dispatched || 0;
+      } else if (action === 'registered') {
+        agent.experience += XP_VALUES.registered || 0;
+      }
     }
 
     // Update space state
@@ -212,6 +327,8 @@ export function getSseClientScript(): string {
     renderAgentList();
     renderSpaceList();
     renderThreadList();
+    renderGuildPanel();
+    renderGuildMap();
     updateEventCount();
   }
 
@@ -395,6 +512,156 @@ export function getSseClientScript(): string {
     if (header) header.textContent = state.threads.size;
   }
 
+  // ============================================================================
+  // Guild Rendering (Phase 5)
+  // ============================================================================
+
+  /**
+   * Get visual state class name
+   */
+  function getVisualStateClass(visualState) {
+    return 'visual-state-' + visualState;
+  }
+
+  /**
+   * Format level display
+   */
+  function formatLevel(level) {
+    return 'Lv.' + level;
+  }
+
+  /**
+   * Format membership status for display
+   */
+  function formatMembershipStatus(status) {
+    if (status === 'active') return 'Active';
+    if (status === 'joined') return 'Joined';
+    return 'Candidate';
+  }
+
+  /**
+   * Render Guild Panel (member list)
+   */
+  function renderGuildPanel() {
+    if (!guildPanelEl) return;
+
+    const now = Date.now();
+
+    if (state.agents.size === 0) {
+      guildPanelEl.innerHTML = '<div class="guild-empty">No guild members yet</div>';
+      return;
+    }
+
+    const agents = Array.from(state.agents.values())
+      .sort(function(a, b) { return b.lastSeenAt - a.lastSeenAt; })
+      .slice(0, 20);
+
+    guildPanelEl.innerHTML = agents.map(function(agent) {
+      const visualState = getVisualState(agent, now);
+      const membershipStatus = getMembershipStatus(agent, now);
+      const level = calcLevel(agent.experience);
+      const displayName = getAgentDisplayName(agent);
+
+      return '<div class="guild-member ' + getVisualStateClass(visualState) + '" data-agent-id="' + escapeHtml(agent.agentId) + '">' +
+        '<div class="guild-member-avatar">' + displayName.charAt(0).toUpperCase() + '</div>' +
+        '<div class="guild-member-info">' +
+          '<div class="guild-member-name">' + escapeHtml(displayName) + '</div>' +
+          '<div class="guild-member-meta">' +
+            '<span class="guild-member-level" title="Session Level (XP: ' + agent.experience + ')">Session ' + formatLevel(level) + '</span>' +
+            '<span class="guild-member-status ' + membershipStatus + '">' + formatMembershipStatus(membershipStatus) + '</span>' +
+          '</div>' +
+          '<div class="guild-member-id" title="' + escapeHtml(agent.agentId) + '">' + truncateId(agent.agentId, 16) + '</div>' +
+        '</div>' +
+        (agent.lastMessagePreview ? '<div class="guild-member-bubble">' + escapeHtml(agent.lastMessagePreview) + '</div>' : '') +
+      '</div>';
+    }).join('');
+  }
+
+  /**
+   * Render Guild Map (rooms with members)
+   */
+  function renderGuildMap() {
+    if (!guildMapEl) return;
+
+    const now = Date.now();
+
+    // Collect rooms from spaces
+    const rooms = [];
+    const lobbyMembers = [];
+
+    // Build room list from spaces
+    state.spaces.forEach(function(space) {
+      rooms.push({
+        spaceId: space.spaceId,
+        spaceName: space.spaceName || truncateId(space.spaceId, 12),
+        members: []
+      });
+    });
+
+    // Place agents in rooms based on currentSpaceId
+    state.agents.forEach(function(agent) {
+      const visualState = getVisualState(agent, now);
+      const level = calcLevel(agent.experience);
+      const memberData = {
+        agentId: agent.agentId,
+        name: getAgentDisplayName(agent),
+        level: level,
+        visualState: visualState,
+        lastMessagePreview: agent.lastMessagePreview
+      };
+
+      if (agent.currentSpaceId) {
+        const room = rooms.find(function(r) { return r.spaceId === agent.currentSpaceId; });
+        if (room) {
+          room.members.push(memberData);
+        } else {
+          // Room not found, put in lobby
+          lobbyMembers.push(memberData);
+        }
+      } else {
+        // No current space, put in lobby
+        lobbyMembers.push(memberData);
+      }
+    });
+
+    // Add lobby room if there are members
+    if (lobbyMembers.length > 0) {
+      rooms.unshift({
+        spaceId: '__lobby__',
+        spaceName: 'Lobby',
+        members: lobbyMembers
+      });
+    }
+
+    // Render rooms
+    if (rooms.length === 0) {
+      guildMapEl.innerHTML = '<div class="guild-map-empty">No rooms yet</div>';
+      return;
+    }
+
+    guildMapEl.innerHTML = rooms.map(function(room) {
+      const memberHtml = room.members.map(function(member) {
+        return '<div class="guild-map-member ' + getVisualStateClass(member.visualState) + '" ' +
+          'data-agent-id="' + escapeHtml(member.agentId) + '" ' +
+          'title="' + escapeHtml(member.name) + ' (' + formatLevel(member.level) + ')">' +
+          '<div class="guild-map-member-avatar">' + member.name.charAt(0).toUpperCase() + '</div>' +
+          '<div class="guild-map-member-name">' + escapeHtml(member.name) + '</div>' +
+          (member.visualState === 'speaking' && member.lastMessagePreview ?
+            '<div class="guild-map-bubble">' + escapeHtml(member.lastMessagePreview) + '</div>' : '') +
+        '</div>';
+      }).join('');
+
+      return '<div class="guild-map-room" data-space-id="' + escapeHtml(room.spaceId) + '">' +
+        '<div class="guild-map-room-header">' +
+          '<span class="guild-map-room-icon">' + (room.spaceId === '__lobby__' ? '🏠' : '🚪') + '</span>' +
+          '<span class="guild-map-room-name">' + escapeHtml(room.spaceName) + '</span>' +
+          '<span class="guild-map-room-count">' + room.members.length + '</span>' +
+        '</div>' +
+        '<div class="guild-map-room-members">' + memberHtml + '</div>' +
+      '</div>';
+    }).join('');
+  }
+
   /**
    * Connect to SSE stream
    */
@@ -456,6 +723,8 @@ export function getSseClientScript(): string {
   renderAgentList();
   renderSpaceList();
   renderThreadList();
+  renderGuildPanel();
+  renderGuildMap();
   connect();
 
   // Cleanup on page unload

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -1,0 +1,342 @@
+/**
+ * ProofPortal - SSE Client (Browser-side)
+ * Phase 4: ProofPortal MVP
+ *
+ * This module generates inline JavaScript for browser-side SSE consumption.
+ * The generated code runs in the browser to receive real-time events from Gateway.
+ */
+
+/**
+ * Get browser-side SSE client script
+ * This is embedded as inline JavaScript in the HTML page.
+ */
+export function getSseClientScript(): string {
+  return `
+(function() {
+  'use strict';
+
+  // ProofComm event kinds to filter
+  const PROOFCOMM_KINDS = [
+    'proofcomm_space',
+    'proofcomm_skill',
+    'proofcomm_document',
+    'proofcomm_route'
+  ];
+
+  // State
+  const state = {
+    threads: new Map(),
+    spaces: new Map(),
+    agents: new Map(),
+    connected: false,
+    eventCount: 0,
+    lastEventTs: 0
+  };
+
+  let eventSource = null;
+  let reconnectAttempts = 0;
+  const MAX_RECONNECT_ATTEMPTS = 10;
+  const RECONNECT_DELAY = 3000;
+
+  // DOM elements
+  const connectionStatus = document.getElementById('connectionStatus');
+  const connectionText = connectionStatus?.querySelector('.connection-text');
+  const eventCountEl = document.getElementById('eventCount');
+  const agentListEl = document.getElementById('agentList');
+  const threadListEl = document.getElementById('threadList');
+  const spaceListEl = document.getElementById('spaceList');
+
+  /**
+   * Update connection status display
+   */
+  function updateConnectionStatus(connected) {
+    state.connected = connected;
+    if (connectionStatus) {
+      connectionStatus.className = 'connection-status ' + (connected ? 'connected' : 'disconnected');
+    }
+    if (connectionText) {
+      connectionText.textContent = connected ? 'Connected' : 'Disconnected';
+    }
+  }
+
+  /**
+   * Update event count display
+   */
+  function updateEventCount() {
+    if (eventCountEl) {
+      eventCountEl.textContent = state.eventCount + ' events';
+    }
+  }
+
+  /**
+   * Format timestamp
+   */
+  function formatTime(ts) {
+    const date = new Date(ts);
+    return date.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false
+    });
+  }
+
+  /**
+   * Escape HTML
+   */
+  function escapeHtml(str) {
+    if (!str) return '';
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /**
+   * Process incoming SSE event
+   */
+  function processEvent(data) {
+    const metadata = data.metadata || {};
+    const agentId = metadata.agent_id || data.client_id;
+    const spaceId = metadata.space_id;
+    const traceId = data.trace_id;
+    const now = data.ts || Date.now();
+
+    state.eventCount++;
+    state.lastEventTs = now;
+
+    // Update agent state
+    if (agentId) {
+      let agent = state.agents.get(agentId);
+      if (!agent) {
+        agent = {
+          agentId: agentId,
+          traceIds: new Set(),
+          spaceIds: new Set(),
+          eventCount: 0,
+          lastSeenAt: now
+        };
+        state.agents.set(agentId, agent);
+      }
+      agent.eventCount++;
+      agent.lastSeenAt = now;
+      if (traceId) agent.traceIds.add(traceId);
+      if (spaceId) agent.spaceIds.add(spaceId);
+    }
+
+    // Update space state
+    if (spaceId) {
+      let space = state.spaces.get(spaceId);
+      if (!space) {
+        space = {
+          spaceId: spaceId,
+          spaceName: metadata.space_name,
+          members: new Set(),
+          messageCount: 0,
+          lastActivityAt: now
+        };
+        state.spaces.set(spaceId, space);
+      }
+      space.lastActivityAt = now;
+      if (metadata.space_name) space.spaceName = metadata.space_name;
+
+      if (metadata.action === 'joined' && agentId) {
+        space.members.add(agentId);
+      } else if (metadata.action === 'left' && agentId) {
+        space.members.delete(agentId);
+      } else if (metadata.action === 'message') {
+        space.messageCount++;
+      }
+    }
+
+    // Update thread state
+    if (traceId) {
+      let thread = state.threads.get(traceId);
+      if (!thread) {
+        thread = {
+          traceId: traceId,
+          participants: new Set(),
+          eventCount: 0,
+          startedAt: now,
+          lastActivityAt: now
+        };
+        state.threads.set(traceId, thread);
+      }
+      thread.eventCount++;
+      thread.lastActivityAt = now;
+      if (agentId) thread.participants.add(agentId);
+    }
+
+    // Update UI
+    renderAgentList();
+    renderSpaceList();
+    renderThreadList();
+    updateEventCount();
+  }
+
+  /**
+   * Render agent list
+   */
+  function renderAgentList() {
+    if (!agentListEl) return;
+
+    if (state.agents.size === 0) {
+      agentListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">👤</div>No agents yet</div>';
+      return;
+    }
+
+    const agents = Array.from(state.agents.values())
+      .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
+      .slice(0, 20);
+
+    agentListEl.innerHTML = agents.map(agent => {
+      return '<div class="list-item">' +
+        '<div class="list-item-title">' + escapeHtml(agent.agentId) + '</div>' +
+        '<div class="list-item-meta">' +
+          '<span>' + agent.eventCount + ' events</span>' +
+          '<span>' + agent.spaceIds.size + ' spaces</span>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+
+    // Update panel header count
+    const header = agentListEl.closest('.panel')?.querySelector('.panel-count');
+    if (header) header.textContent = state.agents.size;
+  }
+
+  /**
+   * Render space list
+   */
+  function renderSpaceList() {
+    if (!spaceListEl) return;
+
+    if (state.spaces.size === 0) {
+      spaceListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🏠</div>No spaces yet</div>';
+      return;
+    }
+
+    const spaces = Array.from(state.spaces.values())
+      .sort((a, b) => b.lastActivityAt - a.lastActivityAt)
+      .slice(0, 20);
+
+    spaceListEl.innerHTML = spaces.map(space => {
+      const name = space.spaceName || space.spaceId;
+      return '<div class="list-item">' +
+        '<div class="list-item-title">' + escapeHtml(name) + '</div>' +
+        '<div class="list-item-meta">' +
+          '<span>' + space.members.size + ' members</span>' +
+          '<span>' + space.messageCount + ' messages</span>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+
+    // Update panel header count
+    const header = spaceListEl.closest('.panel')?.querySelector('.panel-count');
+    if (header) header.textContent = state.spaces.size;
+  }
+
+  /**
+   * Render thread list
+   */
+  function renderThreadList() {
+    if (!threadListEl) return;
+
+    if (state.threads.size === 0) {
+      threadListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🧵</div>No threads yet</div>';
+      return;
+    }
+
+    const threads = Array.from(state.threads.values())
+      .sort((a, b) => b.lastActivityAt - a.lastActivityAt)
+      .slice(0, 50);
+
+    threadListEl.innerHTML = threads.map(thread => {
+      const shortId = thread.traceId.slice(0, 8) + '...';
+      return '<div class="list-item">' +
+        '<div class="list-item-title">' + escapeHtml(shortId) + '</div>' +
+        '<div class="list-item-meta">' +
+          '<span>' + thread.eventCount + ' events</span>' +
+          '<span>' + thread.participants.size + ' agents</span>' +
+          '<span>' + formatTime(thread.lastActivityAt) + '</span>' +
+        '</div>' +
+      '</div>';
+    }).join('');
+
+    // Update panel header count
+    const header = threadListEl.closest('.panel')?.querySelector('.panel-count');
+    if (header) header.textContent = state.threads.size;
+  }
+
+  /**
+   * Connect to SSE stream
+   */
+  function connect() {
+    if (eventSource) {
+      eventSource.close();
+    }
+
+    const kinds = PROOFCOMM_KINDS.join(',');
+    const url = '/events/stream?kinds=' + encodeURIComponent(kinds);
+
+    console.log('[Portal] Connecting to SSE:', url);
+    eventSource = new EventSource(url);
+
+    eventSource.onopen = function() {
+      console.log('[Portal] SSE connected');
+      updateConnectionStatus(true);
+      reconnectAttempts = 0;
+    };
+
+    eventSource.onerror = function(e) {
+      console.error('[Portal] SSE error:', e);
+      updateConnectionStatus(false);
+
+      if (eventSource.readyState === EventSource.CLOSED) {
+        scheduleReconnect();
+      }
+    };
+
+    eventSource.addEventListener('gateway_event', function(e) {
+      try {
+        const data = JSON.parse(e.data);
+        if (PROOFCOMM_KINDS.includes(data.event_kind)) {
+          processEvent(data);
+        }
+      } catch (err) {
+        console.error('[Portal] Failed to parse event:', err);
+      }
+    });
+  }
+
+  /**
+   * Schedule reconnection
+   */
+  function scheduleReconnect() {
+    if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      console.error('[Portal] Max reconnect attempts reached');
+      return;
+    }
+
+    reconnectAttempts++;
+    const delay = RECONNECT_DELAY * Math.min(reconnectAttempts, 5);
+    console.log('[Portal] Reconnecting in', delay, 'ms (attempt', reconnectAttempts, ')');
+
+    setTimeout(connect, delay);
+  }
+
+  // Initialize
+  renderAgentList();
+  renderSpaceList();
+  renderThreadList();
+  connect();
+
+  // Cleanup on page unload
+  window.addEventListener('beforeunload', function() {
+    if (eventSource) {
+      eventSource.close();
+    }
+  });
+})();
+`;
+}

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -176,13 +176,48 @@ export function getSseClientScript(): string {
   }
 
   /**
+   * Get activity class based on last seen time
+   */
+  function getActivityClass(lastSeenAt) {
+    const now = Date.now();
+    const diffSec = (now - lastSeenAt) / 1000;
+    if (diffSec < 30) return 'active';
+    if (diffSec < 300) return 'recent';
+    return 'idle';
+  }
+
+  /**
+   * Format relative time (e.g., "2s ago", "5m ago")
+   */
+  function formatRelativeTime(ts) {
+    const now = Date.now();
+    const diffMs = now - ts;
+    const diffSec = Math.floor(diffMs / 1000);
+    if (diffSec < 60) return diffSec + 's ago';
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) return diffMin + 'm ago';
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return diffHour + 'h ago';
+    return Math.floor(diffHour / 24) + 'd ago';
+  }
+
+  /**
+   * Truncate ID for display
+   */
+  function truncateId(id, maxLen) {
+    if (!id) return '';
+    if (id.length <= maxLen) return id;
+    return id.slice(0, maxLen - 3) + '...';
+  }
+
+  /**
    * Render agent list
    */
   function renderAgentList() {
     if (!agentListEl) return;
 
     if (state.agents.size === 0) {
-      agentListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">👤</div>No agents yet</div>';
+      agentListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">👤</div><div class="empty-state-text">No agents yet</div><div class="empty-state-hint">Agents will appear when events are received</div></div>';
       return;
     }
 
@@ -190,13 +225,20 @@ export function getSseClientScript(): string {
       .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
       .slice(0, 20);
 
-    agentListEl.innerHTML = agents.map(agent => {
-      return '<div class="list-item">' +
-        '<div class="list-item-title">' + escapeHtml(agent.agentId) + '</div>' +
-        '<div class="list-item-meta">' +
-          '<span>' + agent.eventCount + ' events</span>' +
-          '<span>' + agent.spaceIds.size + ' spaces</span>' +
+    agentListEl.innerHTML = agents.map(function(agent) {
+      const activityClass = getActivityClass(agent.lastSeenAt);
+      const displayId = truncateId(agent.agentId, 20);
+      return '<div class="list-item agent-item ' + activityClass + '" data-agent-id="' + escapeHtml(agent.agentId) + '">' +
+        '<div class="agent-header">' +
+          '<span class="agent-indicator ' + activityClass + '"></span>' +
+          '<span class="agent-id" title="' + escapeHtml(agent.agentId) + '">' + escapeHtml(displayId) + '</span>' +
         '</div>' +
+        '<div class="agent-stats">' +
+          '<span class="stat-item" title="Events"><span class="stat-icon">📊</span><span class="stat-value">' + agent.eventCount + '</span></span>' +
+          '<span class="stat-item" title="Spaces"><span class="stat-icon">🏠</span><span class="stat-value">' + agent.spaceIds.size + '</span></span>' +
+          '<span class="stat-item" title="Threads"><span class="stat-icon">🧵</span><span class="stat-value">' + agent.traceIds.size + '</span></span>' +
+        '</div>' +
+        '<div class="agent-time">' + formatRelativeTime(agent.lastSeenAt) + '</div>' +
       '</div>';
     }).join('');
 
@@ -212,7 +254,7 @@ export function getSseClientScript(): string {
     if (!spaceListEl) return;
 
     if (state.spaces.size === 0) {
-      spaceListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🏠</div>No spaces yet</div>';
+      spaceListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🏠</div><div class="empty-state-text">No spaces yet</div><div class="empty-state-hint">Spaces appear when agents join or send messages</div></div>';
       return;
     }
 
@@ -220,13 +262,38 @@ export function getSseClientScript(): string {
       .sort((a, b) => b.lastActivityAt - a.lastActivityAt)
       .slice(0, 20);
 
-    spaceListEl.innerHTML = spaces.map(space => {
-      const name = space.spaceName || space.spaceId;
-      return '<div class="list-item">' +
-        '<div class="list-item-title">' + escapeHtml(name) + '</div>' +
-        '<div class="list-item-meta">' +
-          '<span>' + space.members.size + ' members</span>' +
-          '<span>' + space.messageCount + ' messages</span>' +
+    spaceListEl.innerHTML = spaces.map(function(space) {
+      const displayName = space.spaceName || truncateId(space.spaceId, 12);
+      const memberCount = space.members.size;
+      const isActive = space.messageCount > 0;
+
+      // Render up to 5 member badges
+      const memberArr = Array.from(space.members).slice(0, 5);
+      const memberBadges = memberArr.map(function(agentId) {
+        const initial = agentId.charAt(0).toUpperCase();
+        const shortId = agentId.slice(0, 8);
+        return '<div class="member-badge" title="' + escapeHtml(agentId) + '">' +
+          '<span class="member-avatar">' + initial + '</span>' +
+          '<span class="member-id">' + escapeHtml(shortId) + '</span>' +
+        '</div>';
+      }).join('');
+      const moreMembers = memberCount > 5 ? '<span class="more-members">+' + (memberCount - 5) + '</span>' : '';
+
+      return '<div class="space-card" data-space-id="' + escapeHtml(space.spaceId) + '">' +
+        '<div class="space-header">' +
+          '<div class="space-title">' +
+            '<span class="space-icon">🏠</span>' +
+            '<span class="space-name" title="' + escapeHtml(space.spaceId) + '">' + escapeHtml(displayName) + '</span>' +
+          '</div>' +
+        '</div>' +
+        '<div class="space-stats">' +
+          '<div class="space-stat"><span class="stat-label">Members</span><span class="stat-value">' + memberCount + '</span></div>' +
+          '<div class="space-stat"><span class="stat-label">Messages</span><span class="stat-value">' + space.messageCount + '</span></div>' +
+        '</div>' +
+        '<div class="space-members">' + memberBadges + moreMembers + '</div>' +
+        '<div class="space-activity">' +
+          '<span class="activity-indicator ' + (isActive ? 'active' : '') + '"></span>' +
+          '<span class="activity-text">' + (isActive ? 'Active' : 'Quiet') + '</span>' +
         '</div>' +
       '</div>';
     }).join('');
@@ -237,13 +304,24 @@ export function getSseClientScript(): string {
   }
 
   /**
+   * Format duration in human-readable format
+   */
+  function formatDuration(ms) {
+    if (ms < 1000) return ms + 'ms';
+    var sec = Math.floor(ms / 1000);
+    if (sec < 60) return sec + 's';
+    var min = Math.floor(sec / 60);
+    return min + 'm ' + (sec % 60) + 's';
+  }
+
+  /**
    * Render thread list
    */
   function renderThreadList() {
     if (!threadListEl) return;
 
     if (state.threads.size === 0) {
-      threadListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🧵</div>No threads yet</div>';
+      threadListEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🧵</div><div class="empty-state-text">No threads yet</div><div class="empty-state-hint">Threads appear when traced events arrive</div></div>';
       return;
     }
 
@@ -251,14 +329,23 @@ export function getSseClientScript(): string {
       .sort((a, b) => b.lastActivityAt - a.lastActivityAt)
       .slice(0, 50);
 
-    threadListEl.innerHTML = threads.map(thread => {
-      const shortId = thread.traceId.slice(0, 8) + '...';
-      return '<div class="list-item">' +
-        '<div class="list-item-title">' + escapeHtml(shortId) + '</div>' +
-        '<div class="list-item-meta">' +
-          '<span>' + thread.eventCount + ' events</span>' +
-          '<span>' + thread.participants.size + ' agents</span>' +
-          '<span>' + formatTime(thread.lastActivityAt) + '</span>' +
+    threadListEl.innerHTML = threads.map(function(thread) {
+      const shortId = thread.traceId.slice(0, 8) + '…' + thread.traceId.slice(-4);
+      const participantCount = thread.participants.size;
+      const eventCount = thread.eventCount;
+      const duration = thread.lastActivityAt - thread.startedAt;
+
+      return '<div class="thread-card" data-trace-id="' + escapeHtml(thread.traceId) + '">' +
+        '<div class="thread-header">' +
+          '<span class="thread-id" title="' + escapeHtml(thread.traceId) + '">' + escapeHtml(shortId) + '</span>' +
+          '<span class="thread-meta">' +
+            '<span class="thread-stat">' + eventCount + ' events</span>' +
+            '<span class="thread-stat">' + participantCount + ' agents</span>' +
+          '</span>' +
+        '</div>' +
+        '<div class="thread-footer">' +
+          '<span class="thread-duration">' + formatDuration(duration) + '</span>' +
+          '<span class="thread-time">' + formatTime(thread.lastActivityAt) + '</span>' +
         '</div>' +
       '</div>';
     }).join('');

--- a/src/proofportal/templates/components/AgentList.ts
+++ b/src/proofportal/templates/components/AgentList.ts
@@ -1,0 +1,199 @@
+/**
+ * ProofPortal - AgentList Component
+ * Phase 4.3: Agent activity visualization
+ *
+ * Displays a list of active agents with:
+ * - Activity indicators (event count, last seen)
+ * - Space/thread participation counts
+ * - Click to filter events by agent
+ */
+
+import { escapeHtml } from '../layout.js';
+
+/**
+ * Agent display data
+ */
+export interface AgentDisplayData {
+  agentId: string;
+  eventCount: number;
+  spaceCount: number;
+  threadCount: number;
+  lastSeenAt: number;
+  isActive: boolean;  // activity in last 30 seconds
+}
+
+/**
+ * Format relative time (e.g., "2s ago", "5m ago")
+ */
+export function formatRelativeTime(ts: number): string {
+  const now = Date.now();
+  const diffMs = now - ts;
+  const diffSec = Math.floor(diffMs / 1000);
+
+  if (diffSec < 60) {
+    return `${diffSec}s ago`;
+  }
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) {
+    return `${diffMin}m ago`;
+  }
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) {
+    return `${diffHour}h ago`;
+  }
+  return `${Math.floor(diffHour / 24)}d ago`;
+}
+
+/**
+ * Truncate agent ID for display
+ */
+export function truncateAgentId(agentId: string, maxLen: number = 20): string {
+  if (agentId.length <= maxLen) {
+    return agentId;
+  }
+  return agentId.slice(0, maxLen - 3) + '...';
+}
+
+/**
+ * Get activity class based on last seen time
+ */
+export function getActivityClass(lastSeenAt: number): string {
+  const now = Date.now();
+  const diffSec = (now - lastSeenAt) / 1000;
+
+  if (diffSec < 30) return 'active';
+  if (diffSec < 300) return 'recent';
+  return 'idle';
+}
+
+/**
+ * Render a single agent list item
+ */
+export function renderAgentItem(agent: AgentDisplayData): string {
+  const activityClass = getActivityClass(agent.lastSeenAt);
+  const displayId = truncateAgentId(agent.agentId);
+
+  return `
+    <div class="list-item agent-item ${activityClass}" data-agent-id="${escapeHtml(agent.agentId)}">
+      <div class="agent-header">
+        <span class="agent-indicator ${activityClass}"></span>
+        <span class="agent-id" title="${escapeHtml(agent.agentId)}">${escapeHtml(displayId)}</span>
+      </div>
+      <div class="agent-stats">
+        <span class="stat-item" title="Events">
+          <span class="stat-icon">📊</span>
+          <span class="stat-value">${agent.eventCount}</span>
+        </span>
+        <span class="stat-item" title="Spaces">
+          <span class="stat-icon">🏠</span>
+          <span class="stat-value">${agent.spaceCount}</span>
+        </span>
+        <span class="stat-item" title="Threads">
+          <span class="stat-icon">🧵</span>
+          <span class="stat-value">${agent.threadCount}</span>
+        </span>
+      </div>
+      <div class="agent-time">${formatRelativeTime(agent.lastSeenAt)}</div>
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for agent list
+ */
+export function renderAgentEmptyState(): string {
+  return `
+    <div class="empty-state">
+      <div class="empty-state-icon">👤</div>
+      <div class="empty-state-text">No agents yet</div>
+      <div class="empty-state-hint">Agents will appear when events are received</div>
+    </div>
+  `;
+}
+
+/**
+ * Get AgentList-specific CSS styles
+ */
+export function getAgentListStyles(): string {
+  return `
+    /* Agent list styles */
+    .agent-item {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 10px 12px;
+      border-left: 3px solid var(--border-color);
+      transition: border-color 0.2s, background 0.2s;
+    }
+
+    .agent-item.active {
+      border-left-color: var(--accent-green);
+      background: rgba(63, 185, 80, 0.05);
+    }
+
+    .agent-item.recent {
+      border-left-color: var(--accent-yellow);
+    }
+
+    .agent-item.idle {
+      border-left-color: var(--accent-gray);
+      opacity: 0.7;
+    }
+
+    .agent-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .agent-indicator {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent-gray);
+    }
+
+    .agent-indicator.active {
+      background: var(--accent-green);
+      box-shadow: 0 0 6px var(--accent-green);
+    }
+
+    .agent-indicator.recent {
+      background: var(--accent-yellow);
+    }
+
+    .agent-id {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-primary);
+      font-family: monospace;
+    }
+
+    .agent-stats {
+      display: flex;
+      gap: 12px;
+      font-size: 11px;
+    }
+
+    .stat-item {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      color: var(--text-secondary);
+    }
+
+    .stat-icon {
+      font-size: 10px;
+    }
+
+    .stat-value {
+      color: var(--text-primary);
+      font-weight: 500;
+    }
+
+    .agent-time {
+      font-size: 10px;
+      color: var(--text-secondary);
+    }
+  `;
+}

--- a/src/proofportal/templates/components/GuildMap.ts
+++ b/src/proofportal/templates/components/GuildMap.ts
@@ -1,0 +1,312 @@
+/**
+ * ProofPortal - GuildMap Component
+ * Phase 5: ProofGuild
+ *
+ * Displays spaces as "rooms" with agents inside:
+ * - Lobby for agents without currentSpaceId
+ * - Room for each space with members
+ * - Visual state indicators
+ * - Speaking bubbles
+ */
+
+import { escapeHtml } from '../layout.js';
+import type { GuildVisualState } from '../../types.js';
+
+/**
+ * Room member display data
+ */
+export interface RoomMemberData {
+  agentId: string;
+  name: string;
+  level: number;
+  visualState: GuildVisualState;
+  lastMessagePreview?: string;
+}
+
+/**
+ * Room display data
+ */
+export interface RoomDisplayData {
+  spaceId: string;
+  spaceName: string;
+  isLobby: boolean;
+  members: RoomMemberData[];
+}
+
+/**
+ * Get visual state class for map member
+ */
+export function getMapVisualStateClass(state: GuildVisualState): string {
+  return `visual-state-${state}`;
+}
+
+/**
+ * Format level for map display
+ */
+export function formatMapLevel(level: number): string {
+  return `Lv.${level}`;
+}
+
+/**
+ * Truncate space ID for room header
+ */
+export function truncateSpaceIdForRoom(id: string, maxLen: number = 12): string {
+  if (id.length <= maxLen) {
+    return id;
+  }
+  return id.slice(0, maxLen - 3) + '...';
+}
+
+/**
+ * Render a room member (agent icon)
+ */
+export function renderRoomMember(member: RoomMemberData): string {
+  const initial = member.name.charAt(0).toUpperCase();
+  const isSpeaking = member.visualState === 'speaking';
+
+  return `
+    <div class="guild-map-member ${getMapVisualStateClass(member.visualState)}"
+         data-agent-id="${escapeHtml(member.agentId)}"
+         title="${escapeHtml(member.name)} (${formatMapLevel(member.level)})">
+      <div class="guild-map-member-avatar">${initial}</div>
+      <div class="guild-map-member-name">${escapeHtml(member.name)}</div>
+      ${isSpeaking && member.lastMessagePreview ? `<div class="guild-map-bubble">${escapeHtml(member.lastMessagePreview)}</div>` : ''}
+    </div>
+  `;
+}
+
+/**
+ * Render a room card
+ */
+export function renderRoomCard(room: RoomDisplayData): string {
+  const roomIcon = room.isLobby ? '🏠' : '🚪';
+  const memberCount = room.members.length;
+  const membersHtml = room.members.map(renderRoomMember).join('');
+
+  return `
+    <div class="guild-map-room ${room.isLobby ? 'lobby' : ''}" data-space-id="${escapeHtml(room.spaceId)}">
+      <div class="guild-map-room-header">
+        <span class="guild-map-room-icon">${roomIcon}</span>
+        <span class="guild-map-room-name">${escapeHtml(room.spaceName)}</span>
+        <span class="guild-map-room-count">${memberCount}</span>
+      </div>
+      <div class="guild-map-room-members">
+        ${membersHtml || '<div class="guild-map-room-empty">Empty</div>'}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for guild map
+ */
+export function renderGuildMapEmptyState(): string {
+  return `
+    <div class="guild-map-empty">
+      <div class="guild-map-empty-icon">🗺️</div>
+      <div class="guild-map-empty-text">No rooms yet</div>
+      <div class="guild-map-empty-hint">Rooms appear when spaces are created</div>
+    </div>
+  `;
+}
+
+/**
+ * Get GuildMap-specific CSS styles
+ */
+export function getGuildMapStyles(): string {
+  return `
+    /* Guild map container */
+    .guild-map-content {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 8px;
+      min-height: 200px;
+    }
+
+    /* Room card */
+    .guild-map-room {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .guild-map-room.lobby {
+      border-color: var(--accent-yellow);
+      background: rgba(210, 153, 34, 0.05);
+    }
+
+    .guild-map-room-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: var(--bg-tertiary);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .guild-map-room.lobby .guild-map-room-header {
+      background: rgba(210, 153, 34, 0.1);
+    }
+
+    .guild-map-room-icon {
+      font-size: 14px;
+    }
+
+    .guild-map-room-name {
+      flex: 1;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .guild-map-room-count {
+      background: var(--bg-primary);
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-size: 10px;
+      font-weight: 500;
+      color: var(--text-secondary);
+    }
+
+    /* Room members area */
+    .guild-map-room-members {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      padding: 12px;
+      min-height: 60px;
+    }
+
+    .guild-map-room-empty {
+      color: var(--text-tertiary);
+      font-size: 11px;
+      font-style: italic;
+      width: 100%;
+      text-align: center;
+      padding: 8px;
+    }
+
+    /* Room member (agent) */
+    .guild-map-member {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px;
+      border-radius: 8px;
+      cursor: default;
+      position: relative;
+      transition: background 0.2s;
+    }
+
+    .guild-map-member:hover {
+      background: var(--bg-tertiary);
+    }
+
+    .guild-map-member-avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: var(--accent-purple);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      font-weight: 600;
+      transition: box-shadow 0.2s;
+    }
+
+    /* Visual states for map members */
+    .guild-map-member.visual-state-speaking .guild-map-member-avatar {
+      background: var(--accent-green);
+      box-shadow: 0 0 12px rgba(63, 185, 80, 0.6);
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+
+    .guild-map-member.visual-state-active .guild-map-member-avatar {
+      background: var(--accent-blue);
+      box-shadow: 0 0 6px rgba(88, 166, 255, 0.4);
+    }
+
+    .guild-map-member.visual-state-idle .guild-map-member-avatar {
+      background: var(--accent-gray);
+      opacity: 0.6;
+    }
+
+    @keyframes pulse {
+      0%, 100% { transform: scale(1); }
+      50% { transform: scale(1.05); }
+    }
+
+    .guild-map-member-name {
+      font-size: 10px;
+      color: var(--text-secondary);
+      max-width: 60px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-align: center;
+    }
+
+    /* Speaking bubble in map */
+    .guild-map-bubble {
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-bottom: 8px;
+      background: var(--accent-green);
+      color: white;
+      padding: 6px 10px;
+      border-radius: 12px;
+      font-size: 10px;
+      max-width: 120px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+      z-index: 10;
+    }
+
+    .guild-map-bubble::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 6px solid transparent;
+      border-top-color: var(--accent-green);
+    }
+
+    /* Empty state */
+    .guild-map-empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 32px;
+      color: var(--text-secondary);
+      min-height: 200px;
+    }
+
+    .guild-map-empty-icon {
+      font-size: 40px;
+      margin-bottom: 12px;
+      opacity: 0.5;
+    }
+
+    .guild-map-empty-text {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .guild-map-empty-hint {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      margin-top: 4px;
+    }
+  `;
+}

--- a/src/proofportal/templates/components/GuildPanel.ts
+++ b/src/proofportal/templates/components/GuildPanel.ts
@@ -1,0 +1,284 @@
+/**
+ * ProofPortal - GuildPanel Component
+ * Phase 5: ProofGuild
+ *
+ * Displays guild members with:
+ * - Name and level
+ * - Visual state (speaking/active/idle)
+ * - Membership status
+ * - Agent ID (for debugging)
+ * - Last message preview bubble
+ */
+
+import { escapeHtml } from '../layout.js';
+import type { GuildVisualState, GuildMembershipStatus } from '../../types.js';
+
+/**
+ * Guild member display data
+ */
+export interface GuildMemberDisplayData {
+  agentId: string;
+  name: string;
+  level: number;
+  experience: number;
+  visualState: GuildVisualState;
+  membershipStatus: GuildMembershipStatus;
+  lastMessagePreview?: string;
+  currentSpaceName?: string;
+}
+
+/**
+ * Truncate agent ID for display
+ */
+export function truncateGuildId(id: string, maxLen: number = 16): string {
+  if (id.length <= maxLen) {
+    return id;
+  }
+  return id.slice(0, maxLen - 3) + '...';
+}
+
+/**
+ * Get visual state CSS class
+ */
+export function getVisualStateClass(state: GuildVisualState): string {
+  return `visual-state-${state}`;
+}
+
+/**
+ * Format membership status for display
+ */
+export function formatMembershipStatus(status: GuildMembershipStatus): string {
+  switch (status) {
+    case 'active':
+      return 'Active';
+    case 'joined':
+      return 'Joined';
+    case 'candidate':
+      return 'Candidate';
+    default:
+      return status;
+  }
+}
+
+/**
+ * Format level for display
+ */
+export function formatLevel(level: number): string {
+  return `Lv.${level}`;
+}
+
+/**
+ * Render a guild member card
+ */
+export function renderGuildMemberCard(member: GuildMemberDisplayData): string {
+  const initial = member.name.charAt(0).toUpperCase();
+  const displayId = truncateGuildId(member.agentId);
+  const statusClass = member.membershipStatus;
+
+  return `
+    <div class="guild-member ${getVisualStateClass(member.visualState)}" data-agent-id="${escapeHtml(member.agentId)}">
+      <div class="guild-member-avatar">${initial}</div>
+      <div class="guild-member-info">
+        <div class="guild-member-name">${escapeHtml(member.name)}</div>
+        <div class="guild-member-meta">
+          <span class="guild-member-level" title="Session Level (XP: ${member.experience})">Session ${formatLevel(member.level)}</span>
+          <span class="guild-member-status ${statusClass}">${formatMembershipStatus(member.membershipStatus)}</span>
+        </div>
+        <div class="guild-member-id" title="${escapeHtml(member.agentId)}">${escapeHtml(displayId)}</div>
+      </div>
+      ${member.lastMessagePreview ? `<div class="guild-member-bubble">${escapeHtml(member.lastMessagePreview)}</div>` : ''}
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for guild panel
+ */
+export function renderGuildEmptyState(): string {
+  return `
+    <div class="guild-empty">
+      <div class="guild-empty-icon">⚔️</div>
+      <div class="guild-empty-text">No guild members yet</div>
+      <div class="guild-empty-hint">Members will appear when agents join spaces</div>
+    </div>
+  `;
+}
+
+/**
+ * Get GuildPanel-specific CSS styles
+ */
+export function getGuildPanelStyles(): string {
+  return `
+    /* Guild panel container */
+    .guild-panel-content {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 8px;
+    }
+
+    /* Guild member card */
+    .guild-member {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 10px 12px;
+      background: var(--bg-secondary);
+      border-radius: 8px;
+      border-left: 3px solid var(--border-color);
+      min-width: 220px;
+      max-width: 300px;
+      transition: border-color 0.2s, background 0.2s;
+      position: relative;
+    }
+
+    /* Visual states */
+    .guild-member.visual-state-speaking {
+      border-left-color: var(--accent-green);
+      background: rgba(63, 185, 80, 0.08);
+    }
+
+    .guild-member.visual-state-active {
+      border-left-color: var(--accent-blue);
+      background: rgba(88, 166, 255, 0.05);
+    }
+
+    .guild-member.visual-state-idle {
+      border-left-color: var(--accent-gray);
+      opacity: 0.7;
+    }
+
+    /* Avatar */
+    .guild-member-avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: var(--accent-purple);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+      font-weight: 600;
+      flex-shrink: 0;
+    }
+
+    .guild-member.visual-state-speaking .guild-member-avatar {
+      background: var(--accent-green);
+      box-shadow: 0 0 8px rgba(63, 185, 80, 0.5);
+    }
+
+    .guild-member.visual-state-active .guild-member-avatar {
+      background: var(--accent-blue);
+    }
+
+    .guild-member.visual-state-idle .guild-member-avatar {
+      background: var(--accent-gray);
+    }
+
+    /* Info section */
+    .guild-member-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .guild-member-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-primary);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .guild-member-meta {
+      display: flex;
+      gap: 8px;
+      margin-top: 3px;
+      font-size: 11px;
+    }
+
+    .guild-member-level {
+      color: var(--accent-yellow);
+      font-weight: 500;
+    }
+
+    .guild-member-status {
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      font-weight: 500;
+      text-transform: uppercase;
+    }
+
+    .guild-member-status.active {
+      background: rgba(63, 185, 80, 0.2);
+      color: var(--accent-green);
+    }
+
+    .guild-member-status.joined {
+      background: rgba(88, 166, 255, 0.2);
+      color: var(--accent-blue);
+    }
+
+    .guild-member-status.candidate {
+      background: rgba(139, 148, 158, 0.2);
+      color: var(--accent-gray);
+    }
+
+    .guild-member-id {
+      margin-top: 2px;
+      font-size: 9px;
+      color: var(--text-tertiary);
+      font-family: monospace;
+      opacity: 0.7;
+    }
+
+    /* Message bubble */
+    .guild-member-bubble {
+      position: absolute;
+      top: -8px;
+      right: 12px;
+      background: var(--bg-primary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      padding: 4px 8px;
+      font-size: 10px;
+      color: var(--text-secondary);
+      max-width: 160px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    }
+
+    .guild-member.visual-state-speaking .guild-member-bubble {
+      background: var(--accent-green);
+      color: white;
+      border-color: var(--accent-green);
+    }
+
+    /* Empty state */
+    .guild-empty {
+      text-align: center;
+      padding: 24px;
+      color: var(--text-secondary);
+    }
+
+    .guild-empty-icon {
+      font-size: 32px;
+      margin-bottom: 8px;
+    }
+
+    .guild-empty-text {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .guild-empty-hint {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      margin-top: 4px;
+    }
+  `;
+}

--- a/src/proofportal/templates/components/SpaceView.ts
+++ b/src/proofportal/templates/components/SpaceView.ts
@@ -21,6 +21,10 @@ export interface SpaceMemberData {
 
 /**
  * Space display data
+ *
+ * Note: visibility field was removed as it's not currently available
+ * from ProofComm events. Can be added back when Space metadata includes
+ * visibility information.
  */
 export interface SpaceDisplayData {
   spaceId: string;
@@ -29,7 +33,6 @@ export interface SpaceDisplayData {
   memberCount: number;
   messageCount: number;
   lastActivityAt: number;
-  visibility: 'public' | 'private' | 'unknown';
 }
 
 /**
@@ -46,19 +49,9 @@ export function formatMessageCount(count: number): string {
   return count === 1 ? '1 message' : `${count} messages`;
 }
 
-/**
- * Get visibility badge
- */
-export function getVisibilityBadge(visibility: string): string {
-  switch (visibility) {
-    case 'public':
-      return '<span class="visibility-badge public">🌐 public</span>';
-    case 'private':
-      return '<span class="visibility-badge private">🔒 private</span>';
-    default:
-      return '';
-  }
-}
+// Note: getVisibilityBadge was removed as visibility is not currently
+// available from ProofComm events. The function can be restored when
+// Space metadata includes visibility information.
 
 /**
  * Truncate space ID for display
@@ -89,7 +82,6 @@ export function renderMemberBadge(member: SpaceMemberData): string {
  */
 export function renderSpaceCard(space: SpaceDisplayData): string {
   const displayName = space.spaceName || truncateSpaceId(space.spaceId);
-  const visibilityBadge = getVisibilityBadge(space.visibility);
   const memberBadges = space.members
     .slice(0, 5)
     .map(m => renderMemberBadge(m))
@@ -103,7 +95,6 @@ export function renderSpaceCard(space: SpaceDisplayData): string {
           <span class="space-icon">🏠</span>
           <span class="space-name" title="${escapeHtml(space.spaceId)}">${escapeHtml(displayName)}</span>
         </div>
-        ${visibilityBadge}
       </div>
       <div class="space-stats">
         <div class="space-stat">
@@ -177,22 +168,6 @@ export function getSpaceViewStyles(): string {
       font-size: 13px;
       font-weight: 600;
       color: var(--text-primary);
-    }
-
-    .visibility-badge {
-      font-size: 10px;
-      padding: 2px 6px;
-      border-radius: 10px;
-    }
-
-    .visibility-badge.public {
-      background: rgba(63, 185, 80, 0.15);
-      color: var(--accent-green);
-    }
-
-    .visibility-badge.private {
-      background: rgba(210, 153, 34, 0.15);
-      color: var(--accent-yellow);
     }
 
     .space-stats {

--- a/src/proofportal/templates/components/SpaceView.ts
+++ b/src/proofportal/templates/components/SpaceView.ts
@@ -1,0 +1,295 @@
+/**
+ * ProofPortal - SpaceView Component
+ * Phase 4.5: Space visualization
+ *
+ * Displays autonomous spaces with:
+ * - Member list with join/leave tracking
+ * - Message count and activity
+ * - G3 representative event display
+ */
+
+import { escapeHtml } from '../layout.js';
+
+/**
+ * Space member data
+ */
+export interface SpaceMemberData {
+  agentId: string;
+  isActive: boolean;
+  joinedAt: number;
+}
+
+/**
+ * Space display data
+ */
+export interface SpaceDisplayData {
+  spaceId: string;
+  spaceName: string | null;
+  members: SpaceMemberData[];
+  memberCount: number;
+  messageCount: number;
+  lastActivityAt: number;
+  visibility: 'public' | 'private' | 'unknown';
+}
+
+/**
+ * Format member count with proper pluralization
+ */
+export function formatMemberCount(count: number): string {
+  return count === 1 ? '1 member' : `${count} members`;
+}
+
+/**
+ * Format message count with proper pluralization
+ */
+export function formatMessageCount(count: number): string {
+  return count === 1 ? '1 message' : `${count} messages`;
+}
+
+/**
+ * Get visibility badge
+ */
+export function getVisibilityBadge(visibility: string): string {
+  switch (visibility) {
+    case 'public':
+      return '<span class="visibility-badge public">🌐 public</span>';
+    case 'private':
+      return '<span class="visibility-badge private">🔒 private</span>';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Truncate space ID for display
+ */
+export function truncateSpaceId(spaceId: string): string {
+  if (spaceId.length <= 12) return spaceId;
+  return spaceId.slice(0, 8) + '…';
+}
+
+/**
+ * Render a member avatar/badge
+ */
+export function renderMemberBadge(member: SpaceMemberData): string {
+  const initial = member.agentId.charAt(0).toUpperCase();
+  const activeClass = member.isActive ? 'active' : '';
+  const shortId = member.agentId.slice(0, 8);
+
+  return `
+    <div class="member-badge ${activeClass}" title="${escapeHtml(member.agentId)}">
+      <span class="member-avatar">${initial}</span>
+      <span class="member-id">${escapeHtml(shortId)}</span>
+    </div>
+  `;
+}
+
+/**
+ * Render a space card
+ */
+export function renderSpaceCard(space: SpaceDisplayData): string {
+  const displayName = space.spaceName || truncateSpaceId(space.spaceId);
+  const visibilityBadge = getVisibilityBadge(space.visibility);
+  const memberBadges = space.members
+    .slice(0, 5)
+    .map(m => renderMemberBadge(m))
+    .join('');
+  const moreMembers = space.memberCount > 5 ? `<span class="more-members">+${space.memberCount - 5}</span>` : '';
+
+  return `
+    <div class="space-card" data-space-id="${escapeHtml(space.spaceId)}">
+      <div class="space-header">
+        <div class="space-title">
+          <span class="space-icon">🏠</span>
+          <span class="space-name" title="${escapeHtml(space.spaceId)}">${escapeHtml(displayName)}</span>
+        </div>
+        ${visibilityBadge}
+      </div>
+      <div class="space-stats">
+        <div class="space-stat">
+          <span class="stat-label">Members</span>
+          <span class="stat-value">${space.memberCount}</span>
+        </div>
+        <div class="space-stat">
+          <span class="stat-label">Messages</span>
+          <span class="stat-value">${space.messageCount}</span>
+        </div>
+      </div>
+      <div class="space-members">
+        ${memberBadges}
+        ${moreMembers}
+      </div>
+      <div class="space-activity">
+        <span class="activity-indicator ${space.messageCount > 0 ? 'active' : ''}"></span>
+        <span class="activity-text">${space.messageCount > 0 ? 'Active' : 'Quiet'}</span>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for space view
+ */
+export function renderSpaceEmptyState(): string {
+  return `
+    <div class="empty-state">
+      <div class="empty-state-icon">🏠</div>
+      <div class="empty-state-text">No spaces yet</div>
+      <div class="empty-state-hint">Spaces appear when agents join or send messages</div>
+    </div>
+  `;
+}
+
+/**
+ * Get SpaceView-specific CSS styles
+ */
+export function getSpaceViewStyles(): string {
+  return `
+    /* Space view styles */
+    .space-card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      margin-bottom: 8px;
+      overflow: hidden;
+    }
+
+    .space-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 12px;
+      background: var(--bg-tertiary);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .space-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .space-icon {
+      font-size: 16px;
+    }
+
+    .space-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .visibility-badge {
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 10px;
+    }
+
+    .visibility-badge.public {
+      background: rgba(63, 185, 80, 0.15);
+      color: var(--accent-green);
+    }
+
+    .visibility-badge.private {
+      background: rgba(210, 153, 34, 0.15);
+      color: var(--accent-yellow);
+    }
+
+    .space-stats {
+      display: flex;
+      padding: 10px 12px;
+      gap: 20px;
+    }
+
+    .space-stat {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .space-stat .stat-label {
+      font-size: 10px;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+    }
+
+    .space-stat .stat-value {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--accent-blue);
+    }
+
+    .space-members {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      padding: 8px 12px;
+      border-top: 1px solid var(--border-color);
+    }
+
+    .member-badge {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 3px 8px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 12px;
+      font-size: 11px;
+    }
+
+    .member-badge.active {
+      border-color: var(--accent-green);
+      background: rgba(63, 185, 80, 0.1);
+    }
+
+    .member-avatar {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--accent-purple);
+      color: white;
+      font-size: 10px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .member-id {
+      font-family: monospace;
+      color: var(--text-secondary);
+    }
+
+    .more-members {
+      display: flex;
+      align-items: center;
+      padding: 3px 8px;
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .space-activity {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 12px;
+      background: var(--bg-tertiary);
+      border-top: 1px solid var(--border-color);
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .activity-indicator {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-gray);
+    }
+
+    .activity-indicator.active {
+      background: var(--accent-green);
+      animation: pulse 2s infinite;
+    }
+  `;
+}

--- a/src/proofportal/templates/components/ThreadPanel.ts
+++ b/src/proofportal/templates/components/ThreadPanel.ts
@@ -1,0 +1,337 @@
+/**
+ * ProofPortal - ThreadPanel Component
+ * Phase 4.4: Thread/trace visualization
+ *
+ * Displays events grouped by trace_id with:
+ * - Timeline visualization
+ * - Participant list
+ * - Event details on expansion
+ */
+
+import { escapeHtml } from '../layout.js';
+import type { ProofCommAction } from '../../types.js';
+
+/**
+ * Event display data for thread
+ */
+export interface ThreadEventData {
+  id: string;
+  action: ProofCommAction;
+  eventKind: string;
+  timestamp: number;
+  agentId: string | null;
+  spaceId: string | null;
+  spaceName: string | null;
+  preview: string | null;
+}
+
+/**
+ * Thread display data
+ */
+export interface ThreadDisplayData {
+  traceId: string;
+  events: ThreadEventData[];
+  participants: string[];
+  startedAt: number;
+  lastActivityAt: number;
+  duration: number;
+}
+
+/**
+ * Format timestamp for display
+ */
+export function formatTimestamp(ts: number): string {
+  const date = new Date(ts);
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+/**
+ * Format duration in human-readable format
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  return `${min}m ${sec % 60}s`;
+}
+
+/**
+ * Get action badge class
+ */
+export function getActionClass(action: ProofCommAction): string {
+  switch (action) {
+    case 'message':
+    case 'created':
+      return 'action-success';
+    case 'joined':
+    case 'activated':
+      return 'action-info';
+    case 'left':
+    case 'deactivated':
+      return 'action-warning';
+    case 'delivery_failed':
+    case 'deleted':
+      return 'action-error';
+    default:
+      return 'action-default';
+  }
+}
+
+/**
+ * Get event kind icon
+ */
+export function getEventKindIcon(eventKind: string): string {
+  switch (eventKind) {
+    case 'proofcomm_space':
+      return '🏠';
+    case 'proofcomm_skill':
+      return '🔧';
+    case 'proofcomm_document':
+      return '📄';
+    case 'proofcomm_route':
+      return '🔀';
+    default:
+      return '📌';
+  }
+}
+
+/**
+ * Truncate trace ID for display
+ */
+export function truncateTraceId(traceId: string): string {
+  if (traceId.length <= 12) return traceId;
+  return traceId.slice(0, 8) + '…' + traceId.slice(-4);
+}
+
+/**
+ * Render a single event in the timeline
+ */
+export function renderThreadEvent(event: ThreadEventData): string {
+  const icon = getEventKindIcon(event.eventKind);
+  const actionClass = getActionClass(event.action);
+  const agentDisplay = event.agentId ? escapeHtml(event.agentId.slice(0, 12)) : 'unknown';
+
+  return `
+    <div class="thread-event" data-event-id="${escapeHtml(event.id)}">
+      <div class="event-timeline-dot"></div>
+      <div class="event-content">
+        <div class="event-header">
+          <span class="event-icon">${icon}</span>
+          <span class="event-action ${actionClass}">${escapeHtml(event.action)}</span>
+          <span class="event-agent">${agentDisplay}</span>
+          <span class="event-time">${formatTimestamp(event.timestamp)}</span>
+        </div>
+        ${event.preview ? `<div class="event-preview">${escapeHtml(event.preview)}</div>` : ''}
+        ${event.spaceName ? `<div class="event-space">in ${escapeHtml(event.spaceName)}</div>` : ''}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render a thread card
+ */
+export function renderThreadCard(thread: ThreadDisplayData): string {
+  const shortId = truncateTraceId(thread.traceId);
+  const participantCount = thread.participants.length;
+  const eventCount = thread.events.length;
+
+  return `
+    <div class="thread-card" data-trace-id="${escapeHtml(thread.traceId)}">
+      <div class="thread-header">
+        <span class="thread-id" title="${escapeHtml(thread.traceId)}">${escapeHtml(shortId)}</span>
+        <span class="thread-meta">
+          <span class="thread-stat">${eventCount} events</span>
+          <span class="thread-stat">${participantCount} agents</span>
+        </span>
+      </div>
+      <div class="thread-timeline">
+        ${thread.events.slice(-5).map(e => renderThreadEvent(e)).join('')}
+        ${thread.events.length > 5 ? `<div class="thread-more">+${thread.events.length - 5} more</div>` : ''}
+      </div>
+      <div class="thread-footer">
+        <span class="thread-duration">${formatDuration(thread.duration)}</span>
+        <span class="thread-time">${formatTimestamp(thread.lastActivityAt)}</span>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for thread panel
+ */
+export function renderThreadEmptyState(): string {
+  return `
+    <div class="empty-state">
+      <div class="empty-state-icon">🧵</div>
+      <div class="empty-state-text">No threads yet</div>
+      <div class="empty-state-hint">Threads appear when traced events arrive</div>
+    </div>
+  `;
+}
+
+/**
+ * Get ThreadPanel-specific CSS styles
+ */
+export function getThreadPanelStyles(): string {
+  return `
+    /* Thread panel styles */
+    .thread-card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      margin-bottom: 8px;
+      overflow: hidden;
+    }
+
+    .thread-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 12px;
+      background: var(--bg-tertiary);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .thread-id {
+      font-family: monospace;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--accent-blue);
+    }
+
+    .thread-meta {
+      display: flex;
+      gap: 10px;
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .thread-stat {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .thread-timeline {
+      padding: 8px 12px;
+      position: relative;
+    }
+
+    .thread-timeline::before {
+      content: '';
+      position: absolute;
+      left: 20px;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: var(--border-color);
+    }
+
+    .thread-event {
+      display: flex;
+      gap: 10px;
+      padding: 6px 0;
+      position: relative;
+    }
+
+    .event-timeline-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--bg-secondary);
+      border: 2px solid var(--accent-blue);
+      z-index: 1;
+      flex-shrink: 0;
+      margin-top: 4px;
+    }
+
+    .event-content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .event-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .event-icon {
+      font-size: 12px;
+    }
+
+    .event-action {
+      font-size: 11px;
+      font-weight: 500;
+      padding: 1px 6px;
+      border-radius: 4px;
+    }
+
+    .action-success { background: rgba(63, 185, 80, 0.15); color: var(--accent-green); }
+    .action-info { background: rgba(0, 212, 255, 0.15); color: var(--accent-blue); }
+    .action-warning { background: rgba(210, 153, 34, 0.15); color: var(--accent-yellow); }
+    .action-error { background: rgba(248, 81, 73, 0.15); color: var(--accent-red); }
+    .action-default { background: var(--bg-tertiary); color: var(--text-secondary); }
+
+    .event-agent {
+      font-size: 11px;
+      color: var(--text-secondary);
+      font-family: monospace;
+    }
+
+    .event-time {
+      font-size: 10px;
+      color: var(--text-secondary);
+      margin-left: auto;
+    }
+
+    .event-preview {
+      font-size: 11px;
+      color: var(--text-secondary);
+      margin-top: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .event-space {
+      font-size: 10px;
+      color: var(--accent-purple);
+      margin-top: 2px;
+    }
+
+    .thread-more {
+      text-align: center;
+      font-size: 11px;
+      color: var(--text-secondary);
+      padding: 4px;
+      cursor: pointer;
+    }
+
+    .thread-more:hover {
+      color: var(--accent-blue);
+    }
+
+    .thread-footer {
+      display: flex;
+      justify-content: space-between;
+      padding: 8px 12px;
+      background: var(--bg-tertiary);
+      border-top: 1px solid var(--border-color);
+      font-size: 10px;
+      color: var(--text-secondary);
+    }
+
+    .thread-duration {
+      color: var(--accent-green);
+    }
+  `;
+}

--- a/src/proofportal/templates/components/index.ts
+++ b/src/proofportal/templates/components/index.ts
@@ -35,7 +35,6 @@ export {
   type SpaceDisplayData,
   formatMemberCount,
   formatMessageCount,
-  getVisibilityBadge,
   truncateSpaceId,
   renderMemberBadge,
   renderSpaceCard,

--- a/src/proofportal/templates/components/index.ts
+++ b/src/proofportal/templates/components/index.ts
@@ -41,3 +41,28 @@ export {
   renderSpaceEmptyState,
   getSpaceViewStyles,
 } from './SpaceView.js';
+
+// GuildPanel (Phase 5)
+export {
+  type GuildMemberDisplayData,
+  truncateGuildId,
+  getVisualStateClass,
+  formatMembershipStatus,
+  formatLevel,
+  renderGuildMemberCard,
+  renderGuildEmptyState,
+  getGuildPanelStyles,
+} from './GuildPanel.js';
+
+// GuildMap (Phase 5)
+export {
+  type RoomMemberData,
+  type RoomDisplayData,
+  getMapVisualStateClass,
+  formatMapLevel,
+  truncateSpaceIdForRoom,
+  renderRoomMember,
+  renderRoomCard,
+  renderGuildMapEmptyState,
+  getGuildMapStyles,
+} from './GuildMap.js';

--- a/src/proofportal/templates/components/index.ts
+++ b/src/proofportal/templates/components/index.ts
@@ -1,0 +1,44 @@
+/**
+ * ProofPortal - Component exports
+ * Phase 4: ProofPortal MVP
+ */
+
+// AgentList
+export {
+  type AgentDisplayData,
+  formatRelativeTime,
+  truncateAgentId,
+  getActivityClass,
+  renderAgentItem,
+  renderAgentEmptyState,
+  getAgentListStyles,
+} from './AgentList.js';
+
+// ThreadPanel
+export {
+  type ThreadEventData,
+  type ThreadDisplayData,
+  formatTimestamp,
+  formatDuration,
+  getActionClass,
+  getEventKindIcon,
+  truncateTraceId,
+  renderThreadEvent,
+  renderThreadCard,
+  renderThreadEmptyState,
+  getThreadPanelStyles,
+} from './ThreadPanel.js';
+
+// SpaceView
+export {
+  type SpaceMemberData,
+  type SpaceDisplayData,
+  formatMemberCount,
+  formatMessageCount,
+  getVisibilityBadge,
+  truncateSpaceId,
+  renderMemberBadge,
+  renderSpaceCard,
+  renderSpaceEmptyState,
+  getSpaceViewStyles,
+} from './SpaceView.js';

--- a/src/proofportal/templates/dashboard.ts
+++ b/src/proofportal/templates/dashboard.ts
@@ -1,6 +1,6 @@
 /**
  * ProofPortal - Dashboard template
- * Phase 4: ProofPortal MVP
+ * Phase 5: ProofGuild
  */
 
 import { renderLayout, escapeHtml } from './layout.js';
@@ -18,46 +18,78 @@ export interface DashboardOptions {
  */
 export function renderDashboard(options: DashboardOptions): string {
   const content = `
-  <main class="main">
-    <!-- Left Panel: Agents -->
-    <div class="panel">
-      <div class="panel-header">
-        Agents <span class="panel-count">0</span>
+  <main class="main-guild">
+    <!-- Left Column: Guild Map + Agents -->
+    <div class="panel-column left-column">
+      <!-- Guild Map Panel -->
+      <div class="panel guild-map-panel">
+        <div class="panel-header">
+          Guild Map <span class="panel-count">0</span>
+        </div>
+        <div class="panel-content guild-map-content" id="guildMap">
+          <div class="guild-map-empty">
+            <div class="guild-map-empty-icon">🗺️</div>
+            <div class="guild-map-empty-text">No rooms yet</div>
+            <div class="guild-map-empty-hint">Rooms appear when spaces are created</div>
+          </div>
+        </div>
       </div>
-      <div class="panel-content" id="agentList">
-        <div class="empty-state">
-          <div class="empty-state-icon">👤</div>
-          Waiting for events...
+
+      <!-- Agents Panel (legacy) -->
+      <div class="panel agents-panel">
+        <div class="panel-header">
+          Agents <span class="panel-count">0</span>
+        </div>
+        <div class="panel-content" id="agentList">
+          <div class="empty-state">
+            <div class="empty-state-icon">👤</div>
+            Waiting for events...
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Center Panel: Threads -->
-    <div class="panel">
-      <div class="panel-header">
-        Threads <span class="panel-count">0</span>
-      </div>
-      <div class="panel-content" id="threadList">
-        <div class="empty-state">
-          <div class="empty-state-icon">🧵</div>
-          Waiting for events...
+    <!-- Center Column: Threads -->
+    <div class="panel-column center-column">
+      <div class="panel">
+        <div class="panel-header">
+          Threads <span class="panel-count">0</span>
+        </div>
+        <div class="panel-content" id="threadList">
+          <div class="empty-state">
+            <div class="empty-state-icon">🧵</div>
+            Waiting for events...
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Right Panel: Spaces -->
-    <div class="panel">
-      <div class="panel-header">
-        Spaces <span class="panel-count">0</span>
-      </div>
-      <div class="panel-content" id="spaceList">
-        <div class="empty-state">
-          <div class="empty-state-icon">🏠</div>
-          Waiting for events...
+    <!-- Right Column: Spaces -->
+    <div class="panel-column right-column">
+      <div class="panel">
+        <div class="panel-header">
+          Spaces <span class="panel-count">0</span>
+        </div>
+        <div class="panel-content" id="spaceList">
+          <div class="empty-state">
+            <div class="empty-state-icon">🏠</div>
+            Waiting for events...
+          </div>
         </div>
       </div>
     </div>
   </main>
+
+  <!-- Guild Panel (bottom bar) -->
+  <section class="guild-panel-bar">
+    <div class="guild-panel-header">
+      <span class="guild-panel-title">⚔️ Guild Members</span>
+      <span class="guild-panel-hint">Session XP only</span>
+    </div>
+    <div class="guild-panel-content" id="guildPanel">
+      <div class="guild-empty">No guild members yet</div>
+    </div>
+  </section>
 
   <footer class="stats-bar">
     <div class="stat">
@@ -72,7 +104,7 @@ export function renderDashboard(options: DashboardOptions): string {
   `;
 
   return renderLayout({
-    title: 'ProofPortal - Agent Communication',
+    title: 'ProofPortal - Guild Communication',
     content,
     scripts: getSseClientScript(),
   });

--- a/src/proofportal/templates/dashboard.ts
+++ b/src/proofportal/templates/dashboard.ts
@@ -1,0 +1,79 @@
+/**
+ * ProofPortal - Dashboard template
+ * Phase 4: ProofPortal MVP
+ */
+
+import { renderLayout, escapeHtml } from './layout.js';
+import { getSseClientScript } from '../sse-client.js';
+
+/**
+ * Dashboard options
+ */
+export interface DashboardOptions {
+  generatedAt: string;
+}
+
+/**
+ * Render the main dashboard page
+ */
+export function renderDashboard(options: DashboardOptions): string {
+  const content = `
+  <main class="main">
+    <!-- Left Panel: Agents -->
+    <div class="panel">
+      <div class="panel-header">
+        Agents <span class="panel-count">0</span>
+      </div>
+      <div class="panel-content" id="agentList">
+        <div class="empty-state">
+          <div class="empty-state-icon">👤</div>
+          Waiting for events...
+        </div>
+      </div>
+    </div>
+
+    <!-- Center Panel: Threads -->
+    <div class="panel">
+      <div class="panel-header">
+        Threads <span class="panel-count">0</span>
+      </div>
+      <div class="panel-content" id="threadList">
+        <div class="empty-state">
+          <div class="empty-state-icon">🧵</div>
+          Waiting for events...
+        </div>
+      </div>
+    </div>
+
+    <!-- Right Panel: Spaces -->
+    <div class="panel">
+      <div class="panel-header">
+        Spaces <span class="panel-count">0</span>
+      </div>
+      <div class="panel-content" id="spaceList">
+        <div class="empty-state">
+          <div class="empty-state-icon">🏠</div>
+          Waiting for events...
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="stats-bar">
+    <div class="stat">
+      <span>Generated:</span>
+      <span class="stat-value">${escapeHtml(options.generatedAt)}</span>
+    </div>
+    <div class="stat">
+      <span>Mode:</span>
+      <span class="stat-value">Real-time SSE</span>
+    </div>
+  </footer>
+  `;
+
+  return renderLayout({
+    title: 'ProofPortal - Agent Communication',
+    content,
+    scripts: getSseClientScript(),
+  });
+}

--- a/src/proofportal/templates/index.ts
+++ b/src/proofportal/templates/index.ts
@@ -1,0 +1,7 @@
+/**
+ * ProofPortal - Template exports
+ * Phase 4: ProofPortal MVP
+ */
+
+export { renderLayout, escapeHtml, formatTime, getPortalStyles } from './layout.js';
+export { renderDashboard, type DashboardOptions } from './dashboard.js';

--- a/src/proofportal/templates/index.ts
+++ b/src/proofportal/templates/index.ts
@@ -3,5 +3,5 @@
  * Phase 4: ProofPortal MVP
  */
 
-export { renderLayout, escapeHtml, formatTime, getPortalStyles } from './layout.js';
+export { renderLayout, escapeHtml, formatTime, getPortalStyles, getComponentStyles } from './layout.js';
 export { renderDashboard, type DashboardOptions } from './dashboard.js';

--- a/src/proofportal/templates/layout.ts
+++ b/src/proofportal/templates/layout.ts
@@ -6,6 +6,8 @@
 import { getAgentListStyles } from './components/AgentList.js';
 import { getThreadPanelStyles } from './components/ThreadPanel.js';
 import { getSpaceViewStyles } from './components/SpaceView.js';
+import { getGuildPanelStyles } from './components/GuildPanel.js';
+import { getGuildMapStyles } from './components/GuildMap.js';
 
 /**
  * Escape HTML special characters
@@ -276,6 +278,83 @@ export function getPortalStyles(): string {
       opacity: 0.5;
     }
 
+    /* Guild layout (Phase 5) */
+    .main-guild {
+      display: grid;
+      grid-template-columns: 280px 1fr 320px;
+      gap: 1px;
+      background: var(--border-color);
+      min-height: calc(100vh - 180px);
+    }
+
+    .panel-column {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      background: var(--border-color);
+    }
+
+    .panel-column .panel {
+      flex: 1;
+      min-height: 0;
+    }
+
+    .left-column .guild-map-panel {
+      flex: 2;
+    }
+
+    .left-column .agents-panel {
+      flex: 1;
+      max-height: 200px;
+    }
+
+    .center-column .panel,
+    .right-column .panel {
+      height: 100%;
+    }
+
+    /* Guild panel bar (bottom) */
+    .guild-panel-bar {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border-color);
+      max-height: 120px;
+      overflow: hidden;
+    }
+
+    .guild-panel-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 16px;
+      background: var(--bg-tertiary);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .guild-panel-title {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .guild-panel-hint {
+      font-size: 10px;
+      color: var(--text-tertiary);
+      font-style: italic;
+    }
+
+    .guild-panel-content {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 8px 16px;
+      overflow-x: auto;
+    }
+
+    /* CSS variable for text-tertiary */
+    :root {
+      --text-tertiary: #6e7681;
+    }
+
     /* Stats bar */
     .stats-bar {
       display: flex;
@@ -314,7 +393,8 @@ export function getPortalStyles(): string {
  * Get all component styles combined
  */
 export function getComponentStyles(): string {
-  return getAgentListStyles() + getThreadPanelStyles() + getSpaceViewStyles();
+  return getAgentListStyles() + getThreadPanelStyles() + getSpaceViewStyles() +
+    getGuildPanelStyles() + getGuildMapStyles();
 }
 
 /**

--- a/src/proofportal/templates/layout.ts
+++ b/src/proofportal/templates/layout.ts
@@ -3,6 +3,10 @@
  * Phase 4: ProofPortal MVP
  */
 
+import { getAgentListStyles } from './components/AgentList.js';
+import { getThreadPanelStyles } from './components/ThreadPanel.js';
+import { getSpaceViewStyles } from './components/SpaceView.js';
+
 /**
  * Escape HTML special characters
  */
@@ -293,7 +297,24 @@ export function getPortalStyles(): string {
       color: var(--text-primary);
       font-weight: 500;
     }
+
+    /* Empty state hint */
+    .empty-state-text {
+      margin-bottom: 4px;
+    }
+
+    .empty-state-hint {
+      font-size: 11px;
+      opacity: 0.7;
+    }
   `;
+}
+
+/**
+ * Get all component styles combined
+ */
+export function getComponentStyles(): string {
+  return getAgentListStyles() + getThreadPanelStyles() + getSpaceViewStyles();
 }
 
 /**
@@ -312,6 +333,7 @@ export function renderLayout(options: {
   <title>${escapeHtml(options.title)}</title>
   <style>
 ${getPortalStyles()}
+${getComponentStyles()}
   </style>
 </head>
 <body data-app="portal">

--- a/src/proofportal/templates/layout.ts
+++ b/src/proofportal/templates/layout.ts
@@ -1,0 +1,334 @@
+/**
+ * ProofPortal - Base HTML layout
+ * Phase 4: ProofPortal MVP
+ */
+
+/**
+ * Escape HTML special characters
+ */
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Format timestamp for display
+ */
+export function formatTime(ts: number): string {
+  const date = new Date(ts);
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+/**
+ * Get portal-specific CSS styles
+ */
+export function getPortalStyles(): string {
+  return `
+    :root {
+      --bg-primary: #0d1117;
+      --bg-secondary: #161b22;
+      --bg-tertiary: #21262d;
+      --border-color: #30363d;
+      --text-primary: #e6edf3;
+      --text-secondary: #8b949e;
+      --accent-blue: #00d4ff;
+      --accent-green: #3fb950;
+      --accent-yellow: #d29922;
+      --accent-red: #f85149;
+      --accent-purple: #a371f7;
+      --accent-gray: #6e7681;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      line-height: 1.5;
+      color: var(--text-primary);
+      background: var(--bg-primary);
+      min-height: 100vh;
+    }
+
+    /* Header */
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px 24px;
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border-color);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .header-title {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--text-primary);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .header-title::before {
+      content: '';
+      width: 8px;
+      height: 8px;
+      background: var(--accent-purple);
+      border-radius: 50%;
+    }
+
+    .header-meta {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      font-size: 12px;
+      color: var(--text-secondary);
+    }
+
+    /* Connection status indicator */
+    .connection-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-color);
+      border-radius: 12px;
+      font-size: 11px;
+    }
+
+    .connection-status.connected {
+      border-color: rgba(63, 185, 80, 0.3);
+    }
+
+    .connection-status.disconnected {
+      border-color: rgba(248, 81, 73, 0.3);
+    }
+
+    .connection-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent-gray);
+    }
+
+    .connected .connection-dot {
+      background: var(--accent-green);
+      animation: pulse 2s infinite;
+    }
+
+    .disconnected .connection-dot {
+      background: var(--accent-red);
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    /* Main layout */
+    .main {
+      display: grid;
+      grid-template-columns: 280px 1fr 320px;
+      gap: 1px;
+      background: var(--border-color);
+      min-height: calc(100vh - 49px);
+    }
+
+    .panel {
+      background: var(--bg-primary);
+      overflow-y: auto;
+    }
+
+    .panel-header {
+      padding: 12px 16px;
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border-color);
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    .panel-count {
+      font-weight: normal;
+      color: var(--accent-blue);
+    }
+
+    .panel-content {
+      padding: 8px;
+    }
+
+    /* List items */
+    .list-item {
+      padding: 10px 12px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 6px;
+      margin-bottom: 6px;
+      cursor: pointer;
+      transition: border-color 0.15s;
+    }
+
+    .list-item:hover {
+      border-color: var(--accent-blue);
+    }
+
+    .list-item-title {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--text-primary);
+      margin-bottom: 4px;
+    }
+
+    .list-item-meta {
+      font-size: 11px;
+      color: var(--text-secondary);
+      display: flex;
+      gap: 8px;
+    }
+
+    /* Badge styles */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 6px;
+      border-radius: 10px;
+      font-size: 10px;
+      font-weight: 500;
+    }
+
+    .badge-space { background: rgba(163, 113, 247, 0.15); color: var(--accent-purple); }
+    .badge-agent { background: rgba(0, 212, 255, 0.15); color: var(--accent-blue); }
+    .badge-message { background: rgba(63, 185, 80, 0.15); color: var(--accent-green); }
+    .badge-skill { background: rgba(210, 153, 34, 0.15); color: var(--accent-yellow); }
+
+    /* Event timeline */
+    .event-item {
+      padding: 8px 12px;
+      background: var(--bg-secondary);
+      border-left: 3px solid var(--border-color);
+      margin-bottom: 4px;
+      font-size: 12px;
+    }
+
+    .event-item.space { border-left-color: var(--accent-purple); }
+    .event-item.skill { border-left-color: var(--accent-yellow); }
+    .event-item.document { border-left-color: var(--accent-blue); }
+
+    .event-time {
+      color: var(--text-secondary);
+      font-size: 10px;
+      font-family: monospace;
+    }
+
+    .event-action {
+      color: var(--text-primary);
+      font-weight: 500;
+    }
+
+    .event-preview {
+      color: var(--text-secondary);
+      font-size: 11px;
+      margin-top: 4px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* Empty state */
+    .empty-state {
+      padding: 40px 20px;
+      text-align: center;
+      color: var(--text-secondary);
+    }
+
+    .empty-state-icon {
+      font-size: 32px;
+      margin-bottom: 12px;
+      opacity: 0.5;
+    }
+
+    /* Stats bar */
+    .stats-bar {
+      display: flex;
+      gap: 16px;
+      padding: 8px 16px;
+      background: var(--bg-tertiary);
+      border-top: 1px solid var(--border-color);
+      font-size: 11px;
+      color: var(--text-secondary);
+    }
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .stat-value {
+      color: var(--text-primary);
+      font-weight: 500;
+    }
+  `;
+}
+
+/**
+ * Render the base layout
+ */
+export function renderLayout(options: {
+  title: string;
+  content: string;
+  scripts?: string;
+}): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(options.title)}</title>
+  <style>
+${getPortalStyles()}
+  </style>
+</head>
+<body data-app="portal">
+  <header class="header">
+    <div class="header-title">ProofPortal</div>
+    <div class="header-meta">
+      <div class="connection-status disconnected" id="connectionStatus">
+        <span class="connection-dot"></span>
+        <span class="connection-text">Disconnected</span>
+      </div>
+      <span id="eventCount">0 events</span>
+    </div>
+  </header>
+  ${options.content}
+  <script>
+${options.scripts ?? ''}
+  </script>
+</body>
+</html>`;
+}

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -1,0 +1,256 @@
+/**
+ * ProofPortal - Type definitions
+ * Phase 4: ProofPortal MVP
+ *
+ * State management types for real-time agent communication visualization.
+ * State keys follow vault 3040 specification: trace_id / space_id / agent_id
+ */
+
+import type { GatewayEventKind } from '../db/types.js';
+
+/**
+ * ProofComm event kinds that Portal observes
+ */
+export const PROOFCOMM_EVENT_KINDS: GatewayEventKind[] = [
+  'proofcomm_space',
+  'proofcomm_skill',
+  'proofcomm_document',
+  'proofcomm_route',
+];
+
+/**
+ * ProofComm action types (from events.ts)
+ */
+export type ProofCommAction =
+  // space
+  | 'created' | 'joined' | 'left' | 'message' | 'delivery_failed' | 'updated' | 'deleted'
+  // skill
+  | 'search' | 'match'
+  // document
+  | 'activated' | 'deactivated' | 'context_updated'
+  // route
+  | 'resolved' | 'dispatched';
+
+/**
+ * SSE event data received from Gateway
+ */
+export interface PortalSseEvent {
+  event_kind: GatewayEventKind;
+  client_id: string;
+  ts: number;
+  request_id: string;
+  trace_id?: string | null;
+  target_id?: string | null;
+  method?: string | null;
+  metadata?: ProofCommMetadata | null;
+}
+
+/**
+ * ProofComm metadata from SSE events
+ */
+export interface ProofCommMetadata {
+  action: ProofCommAction;
+  space_id?: string;
+  space_name?: string;
+  agent_id?: string;
+  agent_name?: string;
+  doc_target_id?: string;
+  doc_path?: string;
+  skill_id?: string;
+  skill_name?: string;
+  match_score?: number;
+  message_id?: string;
+  message_preview?: string;
+  task_id?: string;
+  recipient_count?: number;
+  failed_count?: number;
+}
+
+/**
+ * Display-friendly event for UI rendering
+ */
+export interface PortalEventDisplay {
+  id: string;
+  eventKind: GatewayEventKind;
+  action: ProofCommAction;
+  timestamp: number;
+  traceId: string | null;
+  clientId: string;
+  agentId: string | null;
+  spaceId: string | null;
+  spaceName: string | null;
+  preview: string | null;
+  metadata: ProofCommMetadata;
+}
+
+/**
+ * Thread state - events grouped by trace_id
+ */
+export interface ThreadState {
+  traceId: string;
+  events: PortalEventDisplay[];
+  participants: Set<string>;  // agent_ids
+  startedAt: number;
+  lastActivityAt: number;
+}
+
+/**
+ * Space state - events grouped by space_id
+ */
+export interface SpaceState {
+  spaceId: string;
+  spaceName: string | null;
+  members: Set<string>;  // agent_ids (from join/leave events)
+  events: PortalEventDisplay[];
+  messageCount: number;
+  lastActivityAt: number;
+}
+
+/**
+ * Agent state - activity grouped by agent_id
+ */
+export interface AgentState {
+  agentId: string;
+  traceIds: Set<string>;
+  spaceIds: Set<string>;
+  eventCount: number;
+  lastSeenAt: number;
+}
+
+/**
+ * Portal state root
+ */
+export interface PortalState {
+  /** Events grouped by trace_id */
+  threads: Map<string, ThreadState>;
+  /** Events grouped by space_id */
+  spaces: Map<string, SpaceState>;
+  /** Activity grouped by agent_id */
+  agents: Map<string, AgentState>;
+  /** SSE connection status */
+  connected: boolean;
+  /** Last received event timestamp */
+  lastEventTs: number;
+  /** Total event count */
+  eventCount: number;
+}
+
+/**
+ * Create initial empty state
+ */
+export function createInitialState(): PortalState {
+  return {
+    threads: new Map(),
+    spaces: new Map(),
+    agents: new Map(),
+    connected: false,
+    lastEventTs: 0,
+    eventCount: 0,
+  };
+}
+
+/**
+ * Convert SSE event to display format
+ */
+export function toDisplayEvent(event: PortalSseEvent): PortalEventDisplay {
+  const metadata = event.metadata ?? { action: 'message' as ProofCommAction };
+  return {
+    id: event.request_id,
+    eventKind: event.event_kind,
+    action: metadata.action,
+    timestamp: event.ts,
+    traceId: event.trace_id ?? null,
+    clientId: event.client_id,
+    agentId: metadata.agent_id ?? null,
+    spaceId: metadata.space_id ?? null,
+    spaceName: metadata.space_name ?? null,
+    preview: metadata.message_preview ?? null,
+    metadata,
+  };
+}
+
+/**
+ * Update state with a new event
+ */
+export function updateState(state: PortalState, event: PortalSseEvent): PortalState {
+  const display = toDisplayEvent(event);
+  const now = event.ts;
+
+  // Update thread state
+  if (display.traceId) {
+    let thread = state.threads.get(display.traceId);
+    if (!thread) {
+      thread = {
+        traceId: display.traceId,
+        events: [],
+        participants: new Set(),
+        startedAt: now,
+        lastActivityAt: now,
+      };
+      state.threads.set(display.traceId, thread);
+    }
+    thread.events.push(display);
+    thread.lastActivityAt = now;
+    if (display.agentId) {
+      thread.participants.add(display.agentId);
+    }
+  }
+
+  // Update space state
+  if (display.spaceId) {
+    let space = state.spaces.get(display.spaceId);
+    if (!space) {
+      space = {
+        spaceId: display.spaceId,
+        spaceName: display.spaceName,
+        members: new Set(),
+        events: [],
+        messageCount: 0,
+        lastActivityAt: now,
+      };
+      state.spaces.set(display.spaceId, space);
+    }
+    space.events.push(display);
+    space.lastActivityAt = now;
+    if (display.spaceName) {
+      space.spaceName = display.spaceName;
+    }
+
+    // Track membership changes
+    if (display.action === 'joined' && display.agentId) {
+      space.members.add(display.agentId);
+    } else if (display.action === 'left' && display.agentId) {
+      space.members.delete(display.agentId);
+    } else if (display.action === 'message') {
+      space.messageCount++;
+    }
+  }
+
+  // Update agent state
+  const agentId = display.agentId ?? display.clientId;
+  let agent = state.agents.get(agentId);
+  if (!agent) {
+    agent = {
+      agentId,
+      traceIds: new Set(),
+      spaceIds: new Set(),
+      eventCount: 0,
+      lastSeenAt: now,
+    };
+    state.agents.set(agentId, agent);
+  }
+  agent.eventCount++;
+  agent.lastSeenAt = now;
+  if (display.traceId) {
+    agent.traceIds.add(display.traceId);
+  }
+  if (display.spaceId) {
+    agent.spaceIds.add(display.spaceId);
+  }
+
+  // Update global state
+  state.lastEventTs = now;
+  state.eventCount++;
+
+  return state;
+}

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -80,7 +80,8 @@ export interface PortalEventDisplay {
   spaceId: string | null;
   spaceName: string | null;
   preview: string | null;
-  metadata: ProofCommMetadata;
+  /** Metadata from source event, or minimal fallback if source had none */
+  metadata: Partial<ProofCommMetadata> & { action: ProofCommAction };
 }
 
 /**
@@ -170,9 +171,15 @@ export function toDisplayEvent(event: PortalSseEvent): PortalEventDisplay {
 }
 
 /**
- * Update state with a new event
+ * Apply event to state (mutates state in place)
+ *
+ * This function intentionally mutates the state object for performance.
+ * The Maps and Sets are updated in place rather than creating new copies.
+ *
+ * @param state - Portal state to mutate
+ * @param event - SSE event to apply
  */
-export function updateState(state: PortalState, event: PortalSseEvent): PortalState {
+export function applyEvent(state: PortalState, event: PortalSseEvent): void {
   const display = toDisplayEvent(event);
   const now = event.ts;
 
@@ -251,6 +258,4 @@ export function updateState(state: PortalState, event: PortalSseEvent): PortalSt
   // Update global state
   state.lastEventTs = now;
   state.eventCount++;
-
-  return state;
 }

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -1,9 +1,12 @@
 /**
  * ProofPortal - Type definitions
- * Phase 4: ProofPortal MVP
+ * Phase 5: ProofGuild
  *
  * State management types for real-time agent communication visualization.
  * State keys follow vault 3040 specification: trace_id / space_id / agent_id
+ *
+ * ProofGuild extends ProofPortal to treat agents as guild members with
+ * roles, levels, and visual states.
  */
 
 import type { GatewayEventKind } from '../db/types.js';
@@ -29,7 +32,9 @@ export type ProofCommAction =
   // document
   | 'activated' | 'deactivated' | 'context_updated'
   // route
-  | 'resolved' | 'dispatched';
+  | 'resolved' | 'dispatched'
+  // guild (Phase 5)
+  | 'registered';
 
 /**
  * SSE event data received from Gateway
@@ -65,6 +70,81 @@ export interface ProofCommMetadata {
   recipient_count?: number;
   failed_count?: number;
 }
+
+// ============================================================================
+// Guild Types (Phase 5: ProofGuild)
+// ============================================================================
+
+/**
+ * Guild role derived from Space membership
+ */
+export type GuildRole =
+  | 'moderator'   // Space moderator
+  | 'member'      // Space member
+  | 'observer'    // Space observer
+  | 'visitor';    // No space membership
+
+/**
+ * Visual state for guild members
+ */
+export type GuildVisualState =
+  | 'speaking'    // Message within last 10 seconds
+  | 'active'      // Event within last 60 seconds
+  | 'idle';       // Otherwise
+
+/**
+ * Membership status for guild members
+ * Note: 'joined' is used instead of 'member' to avoid confusion with GuildRole
+ */
+export type GuildMembershipStatus =
+  | 'active'      // Recent events (UI: "Active")
+  | 'joined'      // Space membership (UI: "Joined")
+  | 'candidate';  // Registered only (UI: "Candidate")
+
+/**
+ * Guild member representation for UI
+ */
+export interface GuildMember {
+  agentId: string;
+  /** Display name (agent_name from events, or agentId as fallback) */
+  name: string;
+  role: GuildRole;
+  membershipStatus: GuildMembershipStatus;
+  /** Session-only level (resets on page reload) */
+  level: number;
+  /** Session-only experience points */
+  experience: number;
+  /** Current space (last join/message space) */
+  currentSpaceId?: string;
+  currentSpaceName?: string;
+  visualState: GuildVisualState;
+  /** Truncated to 40 chars for bubble display */
+  lastMessagePreview?: string;
+  lastActiveAt?: number;
+  eventCount: number;
+}
+
+/**
+ * Space as a Guild "room" for visualization
+ */
+export interface GuildSpaceRoom {
+  spaceId: string;
+  spaceName: string;
+  /** Agent IDs currently in this room */
+  memberIds: string[];
+}
+
+/**
+ * Guild derived state (computed from PortalState)
+ */
+export interface GuildState {
+  members: Map<string, GuildMember>;
+  rooms: Map<string, GuildSpaceRoom>;
+}
+
+// ============================================================================
+// Portal Event Types
+// ============================================================================
 
 /**
  * Display-friendly event for UI rendering
@@ -109,6 +189,7 @@ export interface SpaceState {
 
 /**
  * Agent state - activity grouped by agent_id
+ * Extended in Phase 5 for Guild support
  */
 export interface AgentState {
   agentId: string;
@@ -116,6 +197,19 @@ export interface AgentState {
   spaceIds: Set<string>;
   eventCount: number;
   lastSeenAt: number;
+  // Phase 5: Guild fields
+  /** Agent name from event metadata */
+  name?: string;
+  /** Last message preview for bubble display */
+  lastMessagePreview?: string;
+  /** Timestamp of last message (for speaking state) */
+  lastMessageAt?: number;
+  /** Current space ID (last join/message space) */
+  currentSpaceId?: string;
+  /** Current space name */
+  currentSpaceName?: string;
+  /** Session XP (not persisted) */
+  experience: number;
 }
 
 /**
@@ -134,6 +228,8 @@ export interface PortalState {
   lastEventTs: number;
   /** Total event count */
   eventCount: number;
+  /** Phase 5: Guild derived state */
+  guild: GuildState;
 }
 
 /**
@@ -147,6 +243,10 @@ export function createInitialState(): PortalState {
     connected: false,
     lastEventTs: 0,
     eventCount: 0,
+    guild: {
+      members: new Map(),
+      rooms: new Map(),
+    },
   };
 }
 
@@ -243,6 +343,7 @@ export function applyEvent(state: PortalState, event: PortalSseEvent): void {
       spaceIds: new Set(),
       eventCount: 0,
       lastSeenAt: now,
+      experience: 0,
     };
     state.agents.set(agentId, agent);
   }
@@ -255,7 +356,160 @@ export function applyEvent(state: PortalState, event: PortalSseEvent): void {
     agent.spaceIds.add(display.spaceId);
   }
 
+  // Phase 5: Guild fields
+  // Extract agent_name from metadata
+  const metadata = event.metadata;
+  if (metadata?.agent_name) {
+    agent.name = metadata.agent_name;
+  }
+
+  // Track currentSpaceId based on join/message/left
+  if (display.action === 'joined' && display.spaceId) {
+    agent.currentSpaceId = display.spaceId;
+    agent.currentSpaceName = display.spaceName ?? undefined;
+    agent.experience += 2; // XP for joining
+  } else if (display.action === 'message' && display.spaceId) {
+    agent.currentSpaceId = display.spaceId;
+    agent.currentSpaceName = display.spaceName ?? undefined;
+    agent.lastMessagePreview = display.preview
+      ? display.preview.slice(0, 40)
+      : undefined;
+    agent.lastMessageAt = now;
+    agent.experience += 5; // XP for message
+  } else if (display.action === 'left' && display.spaceId) {
+    // Clear currentSpaceId if leaving current space
+    if (agent.currentSpaceId === display.spaceId) {
+      agent.currentSpaceId = undefined;
+      agent.currentSpaceName = undefined;
+    }
+  } else if (display.action === 'match') {
+    agent.experience += 10; // XP for skill match
+  } else if (display.action === 'context_updated') {
+    agent.experience += 8; // XP for document context update
+  } else if (display.action === 'dispatched') {
+    agent.experience += 6; // XP for route dispatch
+  }
+
   // Update global state
   state.lastEventTs = now;
   state.eventCount++;
+}
+
+// ============================================================================
+// Guild Helper Functions
+// ============================================================================
+
+/**
+ * Calculate level from XP
+ * Level 1 at 0 XP, Level 2 at 10 XP, etc.
+ */
+export function calcLevel(xp: number): number {
+  return Math.floor(Math.sqrt(xp / 10)) + 1;
+}
+
+/** Speaking threshold: 10 seconds */
+export const SPEAKING_THRESHOLD_MS = 10_000;
+/** Active threshold: 60 seconds */
+export const ACTIVE_THRESHOLD_MS = 60_000;
+
+/**
+ * Determine visual state based on timestamps
+ */
+export function getVisualState(
+  lastMessageAt: number | undefined,
+  lastSeenAt: number,
+  now: number
+): GuildVisualState {
+  if (lastMessageAt && now - lastMessageAt < SPEAKING_THRESHOLD_MS) {
+    return 'speaking';
+  }
+  if (now - lastSeenAt < ACTIVE_THRESHOLD_MS) {
+    return 'active';
+  }
+  return 'idle';
+}
+
+/**
+ * Determine membership status based on activity and space membership
+ */
+export function getMembershipStatus(
+  agent: AgentState,
+  now: number
+): GuildMembershipStatus {
+  if (now - agent.lastSeenAt < ACTIVE_THRESHOLD_MS) {
+    return 'active';
+  }
+  if (agent.spaceIds.size > 0) {
+    return 'joined';
+  }
+  return 'candidate';
+}
+
+/**
+ * Get highest role from space membership
+ * Note: This requires SpaceState to track roles, which is a simplification.
+ * For now, we return 'member' for any space membership.
+ */
+export function getGuildRole(agent: AgentState, spaces: Map<string, SpaceState>): GuildRole {
+  if (agent.spaceIds.size === 0) {
+    return 'visitor';
+  }
+  // For MVP, assume 'member' role for any space membership
+  // Full role tracking would require storing membership role in SpaceState
+  return 'member';
+}
+
+/**
+ * Derive GuildMember from AgentState
+ */
+export function toGuildMember(
+  agent: AgentState,
+  spaces: Map<string, SpaceState>,
+  now: number
+): GuildMember {
+  return {
+    agentId: agent.agentId,
+    name: agent.name ?? agent.agentId,
+    role: getGuildRole(agent, spaces),
+    membershipStatus: getMembershipStatus(agent, now),
+    level: calcLevel(agent.experience),
+    experience: agent.experience,
+    currentSpaceId: agent.currentSpaceId,
+    currentSpaceName: agent.currentSpaceName,
+    visualState: getVisualState(agent.lastMessageAt, agent.lastSeenAt, now),
+    lastMessagePreview: agent.lastMessagePreview,
+    lastActiveAt: agent.lastSeenAt,
+    eventCount: agent.eventCount,
+  };
+}
+
+/**
+ * Derive full GuildState from PortalState
+ */
+export function deriveGuildState(state: PortalState, now: number): GuildState {
+  const members = new Map<string, GuildMember>();
+  const rooms = new Map<string, GuildSpaceRoom>();
+
+  // Derive members from agents
+  for (const agent of state.agents.values()) {
+    members.set(agent.agentId, toGuildMember(agent, state.spaces, now));
+  }
+
+  // Derive rooms from spaces
+  for (const space of state.spaces.values()) {
+    const memberIds: string[] = [];
+    // Find agents whose currentSpaceId matches this space
+    for (const member of members.values()) {
+      if (member.currentSpaceId === space.spaceId) {
+        memberIds.push(member.agentId);
+      }
+    }
+    rooms.set(space.spaceId, {
+      spaceId: space.spaceId,
+      spaceName: space.spaceName ?? space.spaceId,
+      memberIds,
+    });
+  }
+
+  return { members, rooms };
 }


### PR DESCRIPTION
## Summary

- Implement ProofGuild, a logical layer treating agents as guild members with roles, levels, and visual states
- Add self-registration API for external agents (`POST /proofcomm/guild/register`)
- Add XP/Level system (session-only, calculated client-side)
- Add visual states: speaking (10s), active (60s), idle
- Add GuildMap component showing rooms with agent avatars and speaking bubbles
- Add GuildPanel component showing member list with levels and status

## Design Principles

| Principle | Description |
|-----------|-------------|
| PG1 | ProofGuild is a logical layer (not UI name) |
| PG2 | Membership derived from existing data (no new DB) |
| PG3 | Portal is derived view (not source-of-truth) |
| PG4 | Self-registration API for external agents |
| PG5 | XP/Level calculated client-side (session-only) |

## Files Changed

| File | Changes |
|------|---------|
| `src/proofcomm/guild/register.ts` | Self-registration API with rate limiting |
| `src/proofcomm/guild/index.ts` | Module exports |
| `src/proofcomm/events.ts` | Added 'registered' action |
| `src/gateway/proofcommProxy.ts` | Registration route |
| `src/proofportal/types.ts` | Guild types and helpers |
| `src/proofportal/sse-client.ts` | Guild UI rendering |
| `src/proofportal/templates/components/GuildPanel.ts` | Member list component |
| `src/proofportal/templates/components/GuildMap.ts` | Room map component |
| `src/proofportal/templates/dashboard.ts` | Guild UI integration |
| `src/proofportal/templates/layout.ts` | Guild styles |

## Test plan

- [x] All 2444 tests pass (41 new Guild tests)
- [x] Build succeeds
- [ ] Manual test: Portal displays Guild UI
- [ ] Manual test: External agent can self-register

🤖 Generated with [Claude Code](https://claude.com/claude-code)