### PR TITLE
feat(proofguild): Phase 5 - Guild system for agent visualization

### DIFF
--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -1326,7 +1326,7 @@ export function registerProofCommRoutes(
       baseOptions: {
         requestId: request.requestId,
         traceId: request.headers['x-trace-id'] as string | undefined,
-        clientId: clientIp, // Use IP as client ID for unauthenticated requests
+        clientId: clientIp, // Use IP as client ID for external agent (API-key authenticated)
       },
       allowLocal: process.env.NODE_ENV === 'development',
     });

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -1332,7 +1332,7 @@ export function registerProofCommRoutes(
     });
 
     if (!result.ok) {
-      return reply.code(result.statusCode || 500).send({
+      return reply.code(result.statusCode ?? 500).send({
         error: {
           code: 'REGISTRATION_FAILED',
           message: result.error,

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -29,6 +29,10 @@ import { buildDocumentRoute, buildSpaceRoute } from '../proofcomm/routing.js';
 import { emitDocumentEvent, emitSkillEvent } from '../proofcomm/events.js';
 import type { AuditLogger } from './audit.js';
 import type { SpaceVisibility, MemberRole } from '../db/types.js';
+import {
+  registerGuildAgent,
+  type GuildRegisterRequest,
+} from '../proofcomm/guild/index.js';
 
 /**
  * Document registration request body
@@ -1268,5 +1272,51 @@ export function registerProofCommRoutes(
     }
 
     return reply.code(204).send();
+  });
+
+  // ============================================================================
+  // Guild Registration (Phase 5: ProofGuild)
+  // ============================================================================
+
+  // POST /proofcomm/guild/register - Self-register an external agent
+  fastify.post<{
+    Body: GuildRegisterRequest;
+  }>('/proofcomm/guild/register', {
+    // Note: No preHandler auth - this endpoint allows unauthenticated registration
+    schema: {
+      body: {
+        type: 'object',
+        required: ['url'],
+        properties: {
+          url: { type: 'string', minLength: 1 },
+          name: { type: 'string' },
+        },
+      },
+    },
+  }, async (request, reply) => {
+    const clientIp = request.ip || 'unknown';
+
+    const result = await registerGuildAgent(request.body, {
+      targetsStore,
+      auditLogger: options.auditLogger,
+      clientIp,
+      baseOptions: {
+        requestId: request.requestId,
+        traceId: request.headers['x-trace-id'] as string | undefined,
+        clientId: clientIp, // Use IP as client ID for unauthenticated requests
+      },
+      allowLocal: process.env.NODE_ENV === 'development',
+    });
+
+    if (!result.ok) {
+      return reply.code(result.statusCode || 500).send({
+        error: {
+          code: 'REGISTRATION_FAILED',
+          message: result.error,
+        },
+      });
+    }
+
+    return reply.code(201).send(result.response);
   });
 }

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -31,6 +31,8 @@ import type { AuditLogger } from './audit.js';
 import type { SpaceVisibility, MemberRole } from '../db/types.js';
 import {
   registerGuildAgent,
+  validateApiKey,
+  isApiKeyConfigured,
   type GuildRegisterRequest,
 } from '../proofcomm/guild/index.js';
 
@@ -1278,11 +1280,11 @@ export function registerProofCommRoutes(
   // Guild Registration (Phase 5: ProofGuild)
   // ============================================================================
 
-  // POST /proofcomm/guild/register - Self-register an external agent
+  // POST /proofcomm/guild/register - Register an external agent (requires API key)
   fastify.post<{
     Body: GuildRegisterRequest;
   }>('/proofcomm/guild/register', {
-    // Note: No preHandler auth - this endpoint allows unauthenticated registration
+    // Requires GUILD_API_KEY authentication
     schema: {
       body: {
         type: 'object',
@@ -1294,6 +1296,27 @@ export function registerProofCommRoutes(
       },
     },
   }, async (request, reply) => {
+    // Check if API key is configured
+    if (!isApiKeyConfigured()) {
+      return reply.code(503).send({
+        error: {
+          code: 'SERVICE_UNAVAILABLE',
+          message: 'Guild registration is not enabled. Set GUILD_API_KEY to enable.',
+        },
+      });
+    }
+
+    // Validate API key
+    const authHeader = request.headers.authorization;
+    if (!validateApiKey(authHeader)) {
+      return reply.code(401).send({
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Invalid or missing API key. Use Authorization: Bearer <GUILD_API_KEY>',
+        },
+      });
+    }
+
     const clientIp = request.ip || 'unknown';
 
     const result = await registerGuildAgent(request.body, {

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -1290,8 +1290,8 @@ export function registerProofCommRoutes(
         type: 'object',
         required: ['url'],
         properties: {
-          url: { type: 'string', minLength: 1 },
-          name: { type: 'string' },
+          url: { type: 'string', minLength: 1, maxLength: 2048 },
+          name: { type: 'string', maxLength: 128 },
         },
       },
     },

--- a/src/proofcomm/events.ts
+++ b/src/proofcomm/events.ts
@@ -43,6 +43,8 @@ export type ProofCommAction =
   | 'delivery_failed'
   | 'deleted'
   | 'updated'
+  // guild (Phase 5)
+  | 'registered'
   // skill
   | 'search'
   | 'match'
@@ -173,15 +175,15 @@ export function emitProofCommEvent(
  */
 export function emitSpaceEvent(
   auditLogger: AuditLogger,
-  action: 'created' | 'joined' | 'left' | 'message' | 'delivery_failed' | 'deleted' | 'updated',
-  metadata: Omit<ProofCommMetadata, 'action'> & { space_id: string },
+  action: 'created' | 'joined' | 'left' | 'message' | 'delivery_failed' | 'deleted' | 'updated' | 'registered',
+  metadata: Omit<ProofCommMetadata, 'action'> & { space_id?: string; agent_id?: string },
   baseOptions: ProofCommEventBaseOptions
 ): string {
   return emitProofCommEvent(
     auditLogger,
     'proofcomm_space',
     { ...metadata, action },
-    { ...baseOptions, target: baseOptions.target ?? metadata.space_id }
+    { ...baseOptions, target: baseOptions.target ?? metadata.space_id ?? metadata.agent_id }
   );
 }
 
@@ -288,7 +290,7 @@ export function isProofCommEventKind(kind: string): kind is ProofCommEventKind {
  */
 export function isValidAction(kind: ProofCommEventKind, action: string): boolean {
   const validActions: Record<ProofCommEventKind, string[]> = {
-    proofcomm_space: ['created', 'joined', 'left', 'message', 'delivery_failed', 'deleted', 'updated'],
+    proofcomm_space: ['created', 'joined', 'left', 'message', 'delivery_failed', 'deleted', 'updated', 'registered'],
     proofcomm_skill: ['search', 'match', 'refresh'],
     proofcomm_document: ['activated', 'deactivated', 'context_updated'],
     proofcomm_route: ['resolved', 'dispatched'],

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -6,6 +6,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   validateGuildToken,
+  validateApiKey,
+  isApiKeyConfigured,
   getGuildTokenCount,
   cleanupGuildTokens,
 } from '../register.js';
@@ -20,6 +22,34 @@ describe('ProofGuild Registration', () => {
     it('should return null for empty token', () => {
       const result = validateGuildToken('');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('validateApiKey', () => {
+    it('should return false for missing auth header', () => {
+      expect(validateApiKey(undefined)).toBe(false);
+    });
+
+    it('should return false for empty auth header', () => {
+      expect(validateApiKey('')).toBe(false);
+    });
+
+    it('should return false for non-Bearer auth', () => {
+      expect(validateApiKey('Basic abc123')).toBe(false);
+    });
+
+    it('should return false for invalid Bearer format', () => {
+      expect(validateApiKey('Bearer')).toBe(false);
+    });
+
+    // Note: Cannot test valid API key without setting GUILD_API_KEY env var
+    // which would require mocking process.env
+  });
+
+  describe('isApiKeyConfigured', () => {
+    it('should return boolean', () => {
+      const result = isApiKeyConfigured();
+      expect(typeof result).toBe('boolean');
     });
   });
 

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -11,7 +11,15 @@ import {
   getGuildTokenCount,
   cleanupGuildTokens,
   isExternalUrl,
+  registerGuildAgent,
 } from '../register.js';
+
+// Mock fetchAgentCard
+vi.mock('../../../a2a/agent-card.js', () => ({
+  fetchAgentCard: vi.fn(),
+}));
+
+import { fetchAgentCard } from '../../../a2a/agent-card.js';
 
 describe('ProofGuild Registration', () => {
   describe('validateGuildToken', () => {
@@ -143,6 +151,154 @@ describe('ProofGuild Registration', () => {
     it('should return false for invalid URLs', () => {
       expect(isExternalUrl('not-a-url')).toBe(false);
       expect(isExternalUrl('')).toBe(false);
+    });
+  });
+
+  describe('registerGuildAgent', () => {
+    const mockTargetsStore = {
+      add: vi.fn(),
+      list: vi.fn(),
+    };
+
+    const mockAuditLogger = {
+      logEvent: vi.fn(),
+    };
+
+    const baseOptions = {
+      targetsStore: mockTargetsStore as any,
+      auditLogger: mockAuditLogger as any,
+      clientIp: '203.0.113.1',
+      baseOptions: {
+        requestId: 'test-req-id',
+        clientId: 'test-client',
+      },
+      allowLocal: false,
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockTargetsStore.list.mockReturnValue([]);
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('should reject missing URL', async () => {
+      const result = await registerGuildAgent({ url: '' }, baseOptions);
+
+      expect(result.ok).toBe(false);
+      expect(result.statusCode).toBe(400);
+      expect(result.error).toContain('Missing required field');
+    });
+
+    it('should reject invalid URL scheme', async () => {
+      const result = await registerGuildAgent({ url: 'ftp://example.com' }, baseOptions);
+
+      expect(result.ok).toBe(false);
+      expect(result.statusCode).toBe(400);
+      expect(result.error).toContain('must start with http');
+    });
+
+    it('should reject private IP addresses (SSRF protection)', async () => {
+      const result = await registerGuildAgent(
+        { url: 'http://169.254.169.254/latest/meta-data/' },
+        baseOptions
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.statusCode).toBe(400);
+      expect(result.error).toContain('internal/private');
+    });
+
+    it('should reject duplicate URL registration', async () => {
+      const existingUrl = 'https://example.com/agent';
+      mockTargetsStore.list.mockReturnValue([
+        { type: 'agent', config: { url: existingUrl } },
+      ]);
+
+      vi.mocked(fetchAgentCard).mockResolvedValue({
+        ok: true,
+        agentCard: { name: 'Test Agent', url: existingUrl, version: '1.0' },
+      });
+
+      const result = await registerGuildAgent(
+        { url: existingUrl },
+        baseOptions
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.statusCode).toBe(409);
+      expect(result.error).toContain('already registered');
+    });
+
+    it('should reject when AgentCard fetch fails', async () => {
+      vi.mocked(fetchAgentCard).mockResolvedValue({
+        ok: false,
+        error: 'Connection refused',
+      });
+
+      const result = await registerGuildAgent(
+        { url: 'https://example.com/agent' },
+        baseOptions
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.statusCode).toBe(422);
+      expect(result.error).toContain('Connection refused');
+    });
+
+    it('should successfully register agent and return token', async () => {
+      vi.mocked(fetchAgentCard).mockResolvedValue({
+        ok: true,
+        agentCard: { name: 'Test Agent', url: 'https://example.com/agent', version: '1.0' },
+      });
+      mockTargetsStore.add.mockReturnValue({ id: 'test-agent-id' });
+
+      const result = await registerGuildAgent(
+        { url: 'https://example.com/agent' },
+        baseOptions
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.response).toBeDefined();
+      expect(result.response?.agent_id).toBeDefined();
+      expect(result.response?.token).toBeDefined();
+      expect(result.response?.name).toBe('Test Agent');
+      expect(result.response?.expires_at).toBeDefined();
+      expect(mockTargetsStore.add).toHaveBeenCalledOnce();
+    });
+
+    it('should use custom name when provided', async () => {
+      vi.mocked(fetchAgentCard).mockResolvedValue({
+        ok: true,
+        agentCard: { name: 'Default Name', url: 'https://example.com/agent', version: '1.0' },
+      });
+      mockTargetsStore.add.mockReturnValue({ id: 'test-agent-id' });
+
+      const result = await registerGuildAgent(
+        { url: 'https://example.com/agent', name: 'Custom Name' },
+        baseOptions
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.response?.name).toBe('Custom Name');
+    });
+
+    it('should allow local URLs when allowLocal is true', async () => {
+      vi.mocked(fetchAgentCard).mockResolvedValue({
+        ok: true,
+        agentCard: { name: 'Local Agent', url: 'http://localhost:8080', version: '1.0' },
+      });
+      mockTargetsStore.add.mockReturnValue({ id: 'local-agent-id' });
+
+      const result = await registerGuildAgent(
+        { url: 'http://localhost:8080' },
+        { ...baseOptions, allowLocal: true }
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.response?.name).toBe('Local Agent');
     });
   });
 });

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -27,6 +27,10 @@ describe('ProofGuild Registration', () => {
   });
 
   describe('validateApiKey', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
     it('should return false for missing auth header', () => {
       expect(validateApiKey(undefined)).toBe(false);
     });
@@ -43,14 +47,40 @@ describe('ProofGuild Registration', () => {
       expect(validateApiKey('Bearer')).toBe(false);
     });
 
-    // Note: Cannot test valid API key without setting GUILD_API_KEY env var
-    // which would require mocking process.env
+    it('should return true for valid API key', () => {
+      vi.stubEnv('GUILD_API_KEY', 'my-secret-key');
+      expect(validateApiKey('Bearer my-secret-key')).toBe(true);
+    });
+
+    it('should return false for wrong API key', () => {
+      vi.stubEnv('GUILD_API_KEY', 'my-secret-key');
+      expect(validateApiKey('Bearer wrong-key')).toBe(false);
+    });
+
+    it('should return false for different length API key', () => {
+      vi.stubEnv('GUILD_API_KEY', 'short');
+      expect(validateApiKey('Bearer much-longer-key')).toBe(false);
+    });
+
+    it('should return false when no API key is configured', () => {
+      vi.stubEnv('GUILD_API_KEY', '');
+      expect(validateApiKey('Bearer any-key')).toBe(false);
+    });
   });
 
   describe('isApiKeyConfigured', () => {
-    it('should return boolean', () => {
-      const result = isApiKeyConfigured();
-      expect(typeof result).toBe('boolean');
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('should return true when API key is set', () => {
+      vi.stubEnv('GUILD_API_KEY', 'my-secret-key');
+      expect(isApiKeyConfigured()).toBe(true);
+    });
+
+    it('should return false when API key is not set', () => {
+      vi.stubEnv('GUILD_API_KEY', '');
+      expect(isApiKeyConfigured()).toBe(false);
     });
   });
 

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -111,45 +111,47 @@ describe('ProofGuild Registration', () => {
       const now = Date.now();
       vi.setSystemTime(now);
 
-      // Setup mocks for registration
-      const mockTargetsStore = {
-        add: vi.fn().mockReturnValue({ id: 'cleanup-test-agent' }),
-        list: vi.fn().mockReturnValue([]),
-      };
-      const mockAuditLogger = { logEvent: vi.fn() };
+      try {
+        // Setup mocks for registration
+        const mockTargetsStore = {
+          add: vi.fn().mockReturnValue({ id: 'cleanup-test-agent' }),
+          list: vi.fn().mockReturnValue([]),
+        };
+        const mockAuditLogger = { logEvent: vi.fn() };
 
-      vi.mocked(fetchAgentCard).mockResolvedValue({
-        ok: true,
-        agentCard: { name: 'Cleanup Test Agent', url: 'https://cleanup-test.example.com', version: '1.0' },
-      });
+        vi.mocked(fetchAgentCard).mockResolvedValue({
+          ok: true,
+          agentCard: { name: 'Cleanup Test Agent', url: 'https://cleanup-test.example.com', version: '1.0' },
+        });
 
-      const initialCount = getGuildTokenCount();
+        const initialCount = getGuildTokenCount();
 
-      // Register an agent (creates a token with 30-day TTL)
-      const result = await registerGuildAgent(
-        { url: 'https://cleanup-test.example.com' },
-        {
-          targetsStore: mockTargetsStore as any,
-          auditLogger: mockAuditLogger as any,
-          clientIp: '198.51.100.200', // Unique IP to avoid rate limit
-          baseOptions: { requestId: 'cleanup-test', clientId: 'cleanup-client' },
-          allowLocal: false,
-        }
-      );
+        // Register an agent (creates a token with 30-day TTL)
+        const result = await registerGuildAgent(
+          { url: 'https://cleanup-test.example.com' },
+          {
+            targetsStore: mockTargetsStore as any,
+            auditLogger: mockAuditLogger as any,
+            clientIp: '198.51.100.200', // Unique IP to avoid rate limit
+            baseOptions: { requestId: 'cleanup-test', clientId: 'cleanup-client' },
+            allowLocal: false,
+          }
+        );
 
-      expect(result.ok).toBe(true);
-      expect(getGuildTokenCount()).toBe(initialCount + 1);
+        expect(result.ok).toBe(true);
+        expect(getGuildTokenCount()).toBe(initialCount + 1);
 
-      // Advance time past token expiry (30 days + 1 second)
-      const TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-      vi.advanceTimersByTime(TOKEN_TTL_MS + 1000);
+        // Advance time past token expiry (30 days + 1 second)
+        const TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+        vi.advanceTimersByTime(TOKEN_TTL_MS + 1000);
 
-      // Cleanup should remove expired token
-      cleanupGuildTokens();
+        // Cleanup should remove expired token
+        cleanupGuildTokens();
 
-      expect(getGuildTokenCount()).toBe(initialCount);
-
-      vi.useRealTimers();
+        expect(getGuildTokenCount()).toBe(initialCount);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -10,6 +10,7 @@ import {
   isApiKeyConfigured,
   getGuildTokenCount,
   cleanupGuildTokens,
+  isExternalUrl,
 } from '../register.js';
 
 describe('ProofGuild Registration', () => {
@@ -64,6 +65,54 @@ describe('ProofGuild Registration', () => {
   describe('cleanupGuildTokens', () => {
     it('should not throw when called', () => {
       expect(() => cleanupGuildTokens()).not.toThrow();
+    });
+  });
+
+  describe('isExternalUrl (SSRF protection)', () => {
+    it('should return true for external URLs', () => {
+      expect(isExternalUrl('https://example.com')).toBe(true);
+      expect(isExternalUrl('https://api.openai.com/v1')).toBe(true);
+      expect(isExternalUrl('http://github.com')).toBe(true);
+    });
+
+    it('should return false for localhost', () => {
+      expect(isExternalUrl('http://localhost:8080')).toBe(false);
+      expect(isExternalUrl('http://localhost')).toBe(false);
+      expect(isExternalUrl('https://localhost.localdomain')).toBe(false);
+    });
+
+    it('should return false for loopback IP (127.x.x.x)', () => {
+      expect(isExternalUrl('http://127.0.0.1:8080')).toBe(false);
+      expect(isExternalUrl('http://127.1.2.3')).toBe(false);
+    });
+
+    it('should return false for private Class A (10.x.x.x)', () => {
+      expect(isExternalUrl('http://10.0.0.1')).toBe(false);
+      expect(isExternalUrl('http://10.255.255.255')).toBe(false);
+    });
+
+    it('should return false for private Class B (172.16-31.x.x)', () => {
+      expect(isExternalUrl('http://172.16.0.1')).toBe(false);
+      expect(isExternalUrl('http://172.31.255.255')).toBe(false);
+    });
+
+    it('should return false for private Class C (192.168.x.x)', () => {
+      expect(isExternalUrl('http://192.168.0.1')).toBe(false);
+      expect(isExternalUrl('http://192.168.1.1')).toBe(false);
+    });
+
+    it('should return false for link-local (169.254.x.x)', () => {
+      expect(isExternalUrl('http://169.254.0.1')).toBe(false);
+      expect(isExternalUrl('http://169.254.169.254')).toBe(false);
+    });
+
+    it('should return false for IPv6 loopback', () => {
+      expect(isExternalUrl('http://[::1]:8080')).toBe(false);
+    });
+
+    it('should return false for invalid URLs', () => {
+      expect(isExternalUrl('not-a-url')).toBe(false);
+      expect(isExternalUrl('')).toBe(false);
     });
   });
 });

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -104,6 +104,53 @@ describe('ProofGuild Registration', () => {
     it('should not throw when called', () => {
       expect(() => cleanupGuildTokens()).not.toThrow();
     });
+
+    it('should remove expired tokens', async () => {
+      // Use fake timers to control time
+      vi.useFakeTimers();
+      const now = Date.now();
+      vi.setSystemTime(now);
+
+      // Setup mocks for registration
+      const mockTargetsStore = {
+        add: vi.fn().mockReturnValue({ id: 'cleanup-test-agent' }),
+        list: vi.fn().mockReturnValue([]),
+      };
+      const mockAuditLogger = { logEvent: vi.fn() };
+
+      vi.mocked(fetchAgentCard).mockResolvedValue({
+        ok: true,
+        agentCard: { name: 'Cleanup Test Agent', url: 'https://cleanup-test.example.com', version: '1.0' },
+      });
+
+      const initialCount = getGuildTokenCount();
+
+      // Register an agent (creates a token with 30-day TTL)
+      const result = await registerGuildAgent(
+        { url: 'https://cleanup-test.example.com' },
+        {
+          targetsStore: mockTargetsStore as any,
+          auditLogger: mockAuditLogger as any,
+          clientIp: '198.51.100.200', // Unique IP to avoid rate limit
+          baseOptions: { requestId: 'cleanup-test', clientId: 'cleanup-client' },
+          allowLocal: false,
+        }
+      );
+
+      expect(result.ok).toBe(true);
+      expect(getGuildTokenCount()).toBe(initialCount + 1);
+
+      // Advance time past token expiry (30 days + 1 second)
+      const TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+      vi.advanceTimersByTime(TOKEN_TTL_MS + 1000);
+
+      // Cleanup should remove expired token
+      cleanupGuildTokens();
+
+      expect(getGuildTokenCount()).toBe(initialCount);
+
+      vi.useRealTimers();
+    });
   });
 
   describe('isExternalUrl (SSRF protection)', () => {
@@ -117,6 +164,13 @@ describe('ProofGuild Registration', () => {
       expect(isExternalUrl('http://localhost:8080')).toBe(false);
       expect(isExternalUrl('http://localhost')).toBe(false);
       expect(isExternalUrl('https://localhost.localdomain')).toBe(false);
+    });
+
+    it('should return false for localhost subdomains (*.localhost)', () => {
+      // RFC 6761: .localhost is reserved for loopback
+      expect(isExternalUrl('http://foo.localhost')).toBe(false);
+      expect(isExternalUrl('http://bar.localhost:8080')).toBe(false);
+      expect(isExternalUrl('http://sub.domain.localhost')).toBe(false);
     });
 
     it('should return false for loopback IP (127.x.x.x)', () => {
@@ -306,6 +360,59 @@ describe('ProofGuild Registration', () => {
 
       expect(result.ok).toBe(true);
       expect(result.response?.name).toBe('Local Agent');
+    });
+
+    it('should return 429 when rate limit exceeded', async () => {
+      // Use a unique IP for this test to avoid conflicts
+      const rateLimitOptions = {
+        ...baseOptions,
+        clientIp: '198.51.100.99', // TEST-NET-2 IP for isolation
+      };
+
+      // Make 10 requests (within limit)
+      for (let i = 0; i < 10; i++) {
+        await registerGuildAgent({ url: '' }, rateLimitOptions);
+      }
+
+      // 11th request should hit rate limit
+      const result = await registerGuildAgent(
+        { url: 'https://example.com/agent' },
+        rateLimitOptions
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.statusCode).toBe(429);
+      expect(result.error).toContain('Rate limit exceeded');
+    });
+
+    it('should pass correct arguments to targetsStore.add', async () => {
+      const testUrl = 'https://example.com/new-agent';
+      vi.mocked(fetchAgentCard).mockResolvedValue({
+        ok: true,
+        agentCard: { name: 'New Agent', url: testUrl, version: '2.0' },
+      });
+      mockTargetsStore.add.mockReturnValue({ id: 'new-agent-id' });
+
+      // Use unique IP to avoid rate limit from previous tests
+      const options = { ...baseOptions, clientIp: '198.51.100.100' };
+      await registerGuildAgent({ url: testUrl }, options);
+
+      expect(mockTargetsStore.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'agent',
+          protocol: 'a2a',
+          name: 'New Agent',
+          enabled: true,
+          config: expect.objectContaining({
+            schema_version: 1,
+            url: testUrl,
+            source: 'guild_register',
+          }),
+        }),
+        expect.objectContaining({
+          id: expect.any(String),
+        })
+      );
     });
   });
 });

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -19,7 +19,13 @@ vi.mock('../../../a2a/agent-card.js', () => ({
   fetchAgentCard: vi.fn(),
 }));
 
+// Mock emitSpaceEvent
+vi.mock('../../events.js', () => ({
+  emitSpaceEvent: vi.fn(),
+}));
+
 import { fetchAgentCard } from '../../../a2a/agent-card.js';
+import { emitSpaceEvent } from '../../events.js';
 
 describe('ProofGuild Registration', () => {
   describe('validateGuildToken', () => {
@@ -421,6 +427,34 @@ describe('ProofGuild Registration', () => {
         }),
         expect.objectContaining({
           id: expect.any(String),
+        })
+      );
+    });
+
+    it('should emit registered audit event on success', async () => {
+      const testUrl = 'https://example.com/audit-test-agent';
+      vi.mocked(fetchAgentCard).mockResolvedValue({
+        ok: true,
+        agentCard: { name: 'Audit Test Agent', url: testUrl, version: '1.0' },
+      });
+      mockTargetsStore.add.mockReturnValue({ id: 'audit-test-agent-id' });
+
+      // Use unique IP to avoid rate limit from previous tests
+      const options = { ...baseOptions, clientIp: '198.51.100.101' };
+      const result = await registerGuildAgent({ url: testUrl }, options);
+
+      expect(result.ok).toBe(true);
+      expect(vi.mocked(emitSpaceEvent)).toHaveBeenCalledWith(
+        mockAuditLogger,
+        'registered',
+        expect.objectContaining({
+          agent_id: expect.any(String),
+          agent_name: 'Audit Test Agent',
+        }),
+        expect.objectContaining({
+          requestId: 'test-req-id',
+          clientId: 'test-client',
+          target: expect.any(String),
         })
       );
     });

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -213,6 +213,14 @@ describe('ProofGuild Registration', () => {
       expect(isExternalUrl('not-a-url')).toBe(false);
       expect(isExternalUrl('')).toBe(false);
     });
+
+    it('should return false for non-http/https schemes (defense-in-depth)', () => {
+      // Block dangerous schemes even if they pass hostname checks
+      expect(isExternalUrl('file:///etc/passwd')).toBe(false);
+      expect(isExternalUrl('javascript:alert(1)')).toBe(false);
+      expect(isExternalUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+      expect(isExternalUrl('ftp://example.com')).toBe(false);
+    });
   });
 
   describe('registerGuildAgent', () => {

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -148,6 +148,13 @@ describe('ProofGuild Registration', () => {
       expect(isExternalUrl('http://[::1]:8080')).toBe(false);
     });
 
+    it('should return false for IPv6 unique local (fc00::/7)', () => {
+      // fc00::/7 includes both fc and fd prefixes
+      expect(isExternalUrl('http://[fc00::1]')).toBe(false);
+      expect(isExternalUrl('http://[fd00::1]')).toBe(false);
+      expect(isExternalUrl('http://[fd12:3456:789a::1]')).toBe(false);
+    });
+
     it('should return false for invalid URLs', () => {
       expect(isExternalUrl('not-a-url')).toBe(false);
       expect(isExternalUrl('')).toBe(false);

--- a/src/proofcomm/guild/__tests__/register.test.ts
+++ b/src/proofcomm/guild/__tests__/register.test.ts
@@ -1,0 +1,39 @@
+/**
+ * ProofGuild - Registration tests
+ * Phase 5: ProofGuild
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  validateGuildToken,
+  getGuildTokenCount,
+  cleanupGuildTokens,
+} from '../register.js';
+
+describe('ProofGuild Registration', () => {
+  describe('validateGuildToken', () => {
+    it('should return null for invalid token', () => {
+      const result = validateGuildToken('invalid-token-123');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty token', () => {
+      const result = validateGuildToken('');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getGuildTokenCount', () => {
+    it('should return number of registered tokens', () => {
+      const count = getGuildTokenCount();
+      expect(typeof count).toBe('number');
+      expect(count).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('cleanupGuildTokens', () => {
+    it('should not throw when called', () => {
+      expect(() => cleanupGuildTokens()).not.toThrow();
+    });
+  });
+});

--- a/src/proofcomm/guild/index.ts
+++ b/src/proofcomm/guild/index.ts
@@ -17,4 +17,5 @@ export {
   getGuildTokenCount,
   cleanupGuildTokens,
   isExternalUrl,
+  resetCachedTokenSecret,
 } from './register.js';

--- a/src/proofcomm/guild/index.ts
+++ b/src/proofcomm/guild/index.ts
@@ -1,0 +1,17 @@
+/**
+ * ProofGuild Module
+ * Phase 5: ProofGuild
+ *
+ * Agent self-registration and Guild membership management.
+ */
+
+export {
+  type GuildRegisterRequest,
+  type GuildRegisterResponse,
+  type GuildRegisterResult,
+  type RegisterAgentOptions,
+  registerGuildAgent,
+  validateGuildToken,
+  getGuildTokenCount,
+  cleanupGuildTokens,
+} from './register.js';

--- a/src/proofcomm/guild/index.ts
+++ b/src/proofcomm/guild/index.ts
@@ -16,4 +16,5 @@ export {
   validateGuildToken,
   getGuildTokenCount,
   cleanupGuildTokens,
+  isExternalUrl,
 } from './register.js';

--- a/src/proofcomm/guild/index.ts
+++ b/src/proofcomm/guild/index.ts
@@ -2,7 +2,7 @@
  * ProofGuild Module
  * Phase 5: ProofGuild
  *
- * Agent self-registration and Guild membership management.
+ * Agent registration with API key authentication.
  */
 
 export {
@@ -11,6 +11,8 @@ export {
   type GuildRegisterResult,
   type RegisterAgentOptions,
   registerGuildAgent,
+  validateApiKey,
+  isApiKeyConfigured,
   validateGuildToken,
   getGuildTokenCount,
   cleanupGuildTokens,

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -131,7 +131,13 @@ export function isApiKeyConfigured(): boolean {
 
 /**
  * In-memory token store - keyed by token hash for O(1) lookup
- * Note: This is lost on server restart. For production, consider persisting to DB.
+ *
+ * IMPORTANT: Restart behavior
+ * - Tokens are lost on server restart (in-memory only)
+ * - Registered agents persist in targetsStore (DB)
+ * - After restart, agents cannot authenticate (token gone) and cannot re-register (URL conflict 409)
+ * - To recover: manually remove the agent from targets or implement a token renewal endpoint
+ * - For production: consider persisting tokens to DB or implementing token refresh
  */
 const guildTokensByHash = new Map<string, TokenEntry>();
 

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -255,6 +255,12 @@ const LOCALHOST_HOSTNAMES = new Set([
 ]);
 
 /**
+ * Allowed URL schemes for external agent registration
+ * Defense-in-depth: block file://, javascript://, data://, etc.
+ */
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
+
+/**
  * Check if a URL points to an internal/private address (SSRF protection)
  * @returns true if the URL is safe (external), false if internal
  *
@@ -269,6 +275,13 @@ const LOCALHOST_HOSTNAMES = new Set([
 export function isExternalUrl(urlString: string): boolean {
   try {
     const url = new URL(urlString);
+
+    // Defense-in-depth: only allow http/https schemes
+    // Blocks file://, javascript://, data://, etc.
+    if (!ALLOWED_SCHEMES.has(url.protocol)) {
+      return false;
+    }
+
     const hostname = url.hostname.toLowerCase();
 
     // Check localhost names (exact match)
@@ -427,8 +440,15 @@ export async function registerGuildAgent(
   const agentCard = cardResult.agentCard;
   const agentName = request.name || agentCard.name;
 
-  // Register agent in targets store
+  // Generate token and ID BEFORE DB write to avoid partial failure state
+  // If token generation fails, we don't leave an orphaned agent in the DB
   const agentId = ulid();
+  const token = generateToken();
+  const tokenHash = hashToken(token);
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + TOKEN_TTL_MS);
+
+  // Register agent in targets store
   try {
     targetsStore.add({
       type: 'agent',
@@ -439,7 +459,7 @@ export async function registerGuildAgent(
         schema_version: 1,
         url,
         source: 'guild_register',
-        registered_at: new Date().toISOString(),
+        registered_at: now.toISOString(),
       },
     }, { id: agentId });
   } catch (err) {
@@ -450,13 +470,8 @@ export async function registerGuildAgent(
     };
   }
 
-  // Generate token with TTL
-  const token = generateToken();
-  const tokenHash = hashToken(token);
-  const now = new Date();
-  const expiresAt = new Date(now.getTime() + TOKEN_TTL_MS);
-
   // Store token by hash for O(1) lookup
+  // This happens after DB write succeeds, so agent + token are consistent
   guildTokensByHash.set(tokenHash, {
     agentId,
     name: agentName,

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -271,8 +271,14 @@ export function isExternalUrl(urlString: string): boolean {
     const url = new URL(urlString);
     const hostname = url.hostname.toLowerCase();
 
-    // Check localhost names
+    // Check localhost names (exact match)
     if (LOCALHOST_HOSTNAMES.has(hostname)) {
+      return false;
+    }
+
+    // Check localhost subdomains (e.g., foo.localhost, bar.localhost)
+    // Per RFC 6761, .localhost is reserved for loopback
+    if (hostname.endsWith('.localhost')) {
       return false;
     }
 

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -1,9 +1,11 @@
 /**
- * ProofGuild - Agent Self-Registration
+ * ProofGuild - Agent Registration (API Key Protected)
  * Phase 5: ProofGuild
  *
- * Allows external agents (OpenClaw, PicoClaw, etc.) to self-register
- * with the Guild and receive a Bearer token for subsequent API calls.
+ * Allows external agents (OpenClaw, PicoClaw, etc.) to register
+ * with the Guild using API key authentication.
+ *
+ * Security: Registration requires GUILD_API_KEY for authentication.
  */
 
 import { randomBytes, createHmac } from 'crypto';
@@ -56,10 +58,45 @@ export interface GuildRegisterResult {
  */
 interface TokenEntry {
   agentId: string;
-  tokenHash: string;
   name: string;
   createdAt: string;
   expiresAt?: string;
+}
+
+// ============================================================================
+// API Key Authentication
+// ============================================================================
+
+/**
+ * API key for guild registration (required)
+ */
+const GUILD_API_KEY = process.env.GUILD_API_KEY;
+
+/**
+ * Validate API key from Authorization header
+ * @returns true if valid, false otherwise
+ */
+export function validateApiKey(authHeader: string | undefined): boolean {
+  if (!GUILD_API_KEY) {
+    // No API key configured - reject all requests
+    return false;
+  }
+  if (!authHeader) {
+    return false;
+  }
+  // Expected format: "Bearer <key>"
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return false;
+  }
+  return match[1] === GUILD_API_KEY;
+}
+
+/**
+ * Check if API key is configured
+ */
+export function isApiKeyConfigured(): boolean {
+  return !!GUILD_API_KEY;
 }
 
 // ============================================================================
@@ -67,15 +104,20 @@ interface TokenEntry {
 // ============================================================================
 
 /**
- * In-memory token store for registered agents
+ * In-memory token store - keyed by token hash for O(1) lookup
  * Note: This is lost on server restart. For production, consider persisting to DB.
  */
-const guildTokens = new Map<string, TokenEntry>();
+const guildTokensByHash = new Map<string, TokenEntry>();
 
 /**
- * Secret for signing tokens (should be set via environment variable)
+ * Secret for signing tokens (must be set via environment variable in production)
  */
 const GUILD_TOKEN_SECRET = process.env.GUILD_TOKEN_SECRET || 'proofguild-dev-secret';
+
+// Production check for token secret
+if (!process.env.GUILD_TOKEN_SECRET && process.env.NODE_ENV === 'production') {
+  console.error('[ProofGuild] WARNING: GUILD_TOKEN_SECRET not set in production!');
+}
 
 /**
  * Generate a random token
@@ -94,28 +136,32 @@ function hashToken(token: string): string {
 }
 
 /**
- * Validate a token and return the associated agent ID
+ * Validate a token and return the associated agent ID (O(1) lookup)
  */
 export function validateGuildToken(token: string): string | null {
+  if (!token) return null;
+
   const tokenHash = hashToken(token);
-  for (const [agentId, entry] of guildTokens) {
-    if (entry.tokenHash === tokenHash) {
-      // Check expiration
-      if (entry.expiresAt && new Date(entry.expiresAt) < new Date()) {
-        guildTokens.delete(agentId);
-        return null;
-      }
-      return agentId;
-    }
+  const entry = guildTokensByHash.get(tokenHash);
+
+  if (!entry) {
+    return null;
   }
-  return null;
+
+  // Check expiration
+  if (entry.expiresAt && new Date(entry.expiresAt) < new Date()) {
+    guildTokensByHash.delete(tokenHash);
+    return null;
+  }
+
+  return entry.agentId;
 }
 
 /**
- * Get all registered guild tokens (for debugging)
+ * Get all registered guild tokens count (for debugging)
  */
 export function getGuildTokenCount(): number {
-  return guildTokens.size;
+  return guildTokensByHash.size;
 }
 
 // ============================================================================
@@ -164,6 +210,8 @@ export interface RegisterAgentOptions {
 
 /**
  * Register an external agent with the Guild
+ *
+ * Prerequisites: API key must be validated before calling this function.
  *
  * Flow:
  * 1. Rate limit check
@@ -266,10 +314,9 @@ export async function registerGuildAgent(
   const tokenHash = hashToken(token);
   const now = new Date().toISOString();
 
-  // Store token
-  guildTokens.set(agentId, {
+  // Store token by hash for O(1) lookup
+  guildTokensByHash.set(tokenHash, {
     agentId,
-    tokenHash,
     name: agentName,
     createdAt: now,
     // No expiration for MVP
@@ -306,9 +353,9 @@ export function cleanupGuildTokens(): void {
   const now = Date.now();
 
   // Clean up expired tokens
-  for (const [agentId, entry] of guildTokens) {
+  for (const [hash, entry] of guildTokensByHash) {
     if (entry.expiresAt && new Date(entry.expiresAt).getTime() < now) {
-      guildTokens.delete(agentId);
+      guildTokensByHash.delete(hash);
     }
   }
 
@@ -319,3 +366,7 @@ export function cleanupGuildTokens(): void {
     }
   }
 }
+
+// Start periodic cleanup (every 5 minutes)
+const cleanupInterval = setInterval(cleanupGuildTokens, 5 * 60 * 1000);
+cleanupInterval.unref(); // Don't block process exit

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -10,7 +10,7 @@
 
 import { randomBytes, createHmac, timingSafeEqual } from 'crypto';
 import { fetchAgentCard, type FetchAgentCardResult } from '../../a2a/agent-card.js';
-import { TargetsStore, type TargetWithConfig } from '../../db/targets-store.js';
+import { TargetsStore } from '../../db/targets-store.js';
 import { emitSpaceEvent, type ProofCommEventBaseOptions } from '../events.js';
 import type { AuditLogger } from '../../gateway/audit.js';
 import { ulid } from 'ulid';
@@ -77,7 +77,15 @@ function getApiKey(): string | undefined {
 
 /**
  * Compute HMAC digest for timing-safe comparison
- * Using HMAC ensures constant-length comparison regardless of input length
+ *
+ * Using HMAC ensures constant-length output (32 bytes for SHA-256) regardless
+ * of input length, which is necessary for timingSafeEqual to work correctly.
+ *
+ * The hardcoded key 'api-key-comparison' provides no cryptographic strength -
+ * it only serves to normalize input lengths. This is intentional: we are not
+ * trying to hide the API key (both parties already know it), just prevent
+ * timing-based length inference during comparison. The key does not need
+ * rotation as it has no security function beyond length normalization.
  */
 function hmacDigest(value: string): Buffer {
   return createHmac('sha256', 'api-key-comparison')
@@ -406,9 +414,8 @@ export async function registerGuildAgent(
 
   // Register agent in targets store
   const agentId = ulid();
-  let target: TargetWithConfig;
   try {
-    target = targetsStore.add({
+    targetsStore.add({
       type: 'agent',
       protocol: 'a2a',
       name: agentName,

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -8,7 +8,7 @@
  * Security: Registration requires GUILD_API_KEY for authentication.
  */
 
-import { randomBytes, createHmac } from 'crypto';
+import { randomBytes, createHmac, timingSafeEqual } from 'crypto';
 import { fetchAgentCard, type FetchAgentCardResult } from '../../a2a/agent-card.js';
 import { TargetsStore, type TargetWithConfig } from '../../db/targets-store.js';
 import { emitSpaceEvent, type ProofCommEventBaseOptions } from '../events.js';
@@ -73,7 +73,7 @@ interface TokenEntry {
 const GUILD_API_KEY = process.env.GUILD_API_KEY;
 
 /**
- * Validate API key from Authorization header
+ * Validate API key from Authorization header using timing-safe comparison
  * @returns true if valid, false otherwise
  */
 export function validateApiKey(authHeader: string | undefined): boolean {
@@ -89,7 +89,15 @@ export function validateApiKey(authHeader: string | undefined): boolean {
   if (!match) {
     return false;
   }
-  return match[1] === GUILD_API_KEY;
+  const providedKey = match[1];
+  // Use timing-safe comparison to prevent timing attacks
+  if (providedKey.length !== GUILD_API_KEY.length) {
+    return false;
+  }
+  return timingSafeEqual(
+    Buffer.from(providedKey, 'utf-8'),
+    Buffer.from(GUILD_API_KEY, 'utf-8')
+  );
 }
 
 /**
@@ -112,12 +120,23 @@ const guildTokensByHash = new Map<string, TokenEntry>();
 /**
  * Secret for signing tokens (must be set via environment variable in production)
  */
-const GUILD_TOKEN_SECRET = process.env.GUILD_TOKEN_SECRET || 'proofguild-dev-secret';
-
-// Production check for token secret
-if (!process.env.GUILD_TOKEN_SECRET && process.env.NODE_ENV === 'production') {
-  console.error('[ProofGuild] WARNING: GUILD_TOKEN_SECRET not set in production!');
+function getTokenSecret(): string {
+  const secret = process.env.GUILD_TOKEN_SECRET;
+  if (!secret) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('[ProofGuild] GUILD_TOKEN_SECRET must be set in production');
+    }
+    return 'proofguild-dev-secret';
+  }
+  return secret;
 }
+
+const GUILD_TOKEN_SECRET = getTokenSecret();
+
+/**
+ * Token TTL in milliseconds (30 days)
+ */
+const TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Generate a random token
@@ -162,6 +181,69 @@ export function validateGuildToken(token: string): string | null {
  */
 export function getGuildTokenCount(): number {
   return guildTokensByHash.size;
+}
+
+// ============================================================================
+// SSRF Protection
+// ============================================================================
+
+/**
+ * Private/internal IP ranges that should be blocked for SSRF protection
+ */
+const PRIVATE_IP_PATTERNS = [
+  /^127\./,                          // Loopback (127.0.0.0/8)
+  /^10\./,                           // Private Class A (10.0.0.0/8)
+  /^172\.(1[6-9]|2\d|3[01])\./,      // Private Class B (172.16.0.0/12)
+  /^192\.168\./,                     // Private Class C (192.168.0.0/16)
+  /^169\.254\./,                     // Link-local (169.254.0.0/16)
+  /^0\./,                            // Current network (0.0.0.0/8)
+  /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./, // Carrier-grade NAT (100.64.0.0/10)
+  /^192\.0\.0\./,                    // IETF Protocol Assignments (192.0.0.0/24)
+  /^192\.0\.2\./,                    // TEST-NET-1 (192.0.2.0/24)
+  /^198\.51\.100\./,                 // TEST-NET-2 (198.51.100.0/24)
+  /^203\.0\.113\./,                  // TEST-NET-3 (203.0.113.0/24)
+  /^::1$/,                           // IPv6 loopback
+  /^fc00:/i,                         // IPv6 unique local
+  /^fe80:/i,                         // IPv6 link-local
+];
+
+/**
+ * Common localhost hostnames
+ */
+const LOCALHOST_HOSTNAMES = new Set([
+  'localhost',
+  'localhost.localdomain',
+  '0.0.0.0',
+  '::1',
+  '[::1]',
+]);
+
+/**
+ * Check if a URL points to an internal/private address (SSRF protection)
+ * @returns true if the URL is safe (external), false if internal
+ */
+export function isExternalUrl(urlString: string): boolean {
+  try {
+    const url = new URL(urlString);
+    const hostname = url.hostname.toLowerCase();
+
+    // Check localhost names
+    if (LOCALHOST_HOSTNAMES.has(hostname)) {
+      return false;
+    }
+
+    // Check private IP patterns
+    for (const pattern of PRIVATE_IP_PATTERNS) {
+      if (pattern.test(hostname)) {
+        return false;
+      }
+    }
+
+    return true;
+  } catch {
+    // Invalid URL - treat as unsafe
+    return false;
+  }
 }
 
 // ============================================================================
@@ -255,6 +337,15 @@ export async function registerGuildAgent(
     };
   }
 
+  // SSRF protection: Block internal/private IP addresses (unless allowLocal is set)
+  if (!allowLocal && !isExternalUrl(url)) {
+    return {
+      ok: false,
+      error: 'Invalid URL: internal/private addresses are not allowed',
+      statusCode: 400,
+    };
+  }
+
   // Fetch AgentCard
   const cardResult: FetchAgentCardResult = await fetchAgentCard(url, {
     allowLocal,
@@ -309,17 +400,18 @@ export async function registerGuildAgent(
     };
   }
 
-  // Generate token
+  // Generate token with TTL
   const token = generateToken();
   const tokenHash = hashToken(token);
-  const now = new Date().toISOString();
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + TOKEN_TTL_MS);
 
   // Store token by hash for O(1) lookup
   guildTokensByHash.set(tokenHash, {
     agentId,
     name: agentName,
-    createdAt: now,
-    // No expiration for MVP
+    createdAt: now.toISOString(),
+    expiresAt: expiresAt.toISOString(),
   });
 
   // Emit 'registered' event
@@ -342,6 +434,7 @@ export async function registerGuildAgent(
       agent_id: agentId,
       token,
       name: agentName,
+      expires_at: expiresAt.toISOString(),
     },
   };
 }

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -162,6 +162,14 @@ function getTokenSecret(): string {
 }
 
 /**
+ * Reset cached token secret (for test isolation)
+ * Exported for testing only - allows vi.stubEnv to take effect
+ */
+export function resetCachedTokenSecret(): void {
+  cachedTokenSecret = null;
+}
+
+/**
  * Token TTL in milliseconds (30 days)
  */
 const TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
@@ -231,8 +239,8 @@ const PRIVATE_IP_PATTERNS = [
   /^198\.51\.100\./,                 // TEST-NET-2 (198.51.100.0/24)
   /^203\.0\.113\./,                  // TEST-NET-3 (203.0.113.0/24)
   /^::1$/,                           // IPv6 loopback
-  /^fc00:/i,                         // IPv6 unique local
-  /^fe80:/i,                         // IPv6 link-local
+  /^\[?f[cd][0-9a-f]{2}:/i,          // IPv6 unique local (fc00::/7 includes fc and fd prefixes)
+  /^\[?fe80:/i,                      // IPv6 link-local
 ];
 
 /**
@@ -382,6 +390,20 @@ export async function registerGuildAgent(
     };
   }
 
+  // Check if agent is already registered (by URL) - do this BEFORE fetchAgentCard
+  // to avoid unnecessary outbound HTTP calls on re-registration attempts
+  const existingTargets = targetsStore.list({ type: 'agent' });
+  for (const target of existingTargets) {
+    const config = target.config as { url?: string } | undefined;
+    if (config?.url === url) {
+      return {
+        ok: false,
+        error: 'Agent already registered with this URL',
+        statusCode: 409,
+      };
+    }
+  }
+
   // Fetch AgentCard
   const cardResult: FetchAgentCardResult = await fetchAgentCard(url, {
     allowLocal,
@@ -398,19 +420,6 @@ export async function registerGuildAgent(
 
   const agentCard = cardResult.agentCard;
   const agentName = request.name || agentCard.name;
-
-  // Check if agent is already registered (by URL)
-  const existingTargets = targetsStore.list({ type: 'agent' });
-  for (const target of existingTargets) {
-    const config = target.config as { url?: string } | undefined;
-    if (config?.url === url) {
-      return {
-        ok: false,
-        error: 'Agent already registered with this URL',
-        statusCode: 409,
-      };
-    }
-  }
 
   // Register agent in targets store
   const agentId = ulid();

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -1,0 +1,321 @@
+/**
+ * ProofGuild - Agent Self-Registration
+ * Phase 5: ProofGuild
+ *
+ * Allows external agents (OpenClaw, PicoClaw, etc.) to self-register
+ * with the Guild and receive a Bearer token for subsequent API calls.
+ */
+
+import { randomBytes, createHmac } from 'crypto';
+import { fetchAgentCard, type FetchAgentCardResult } from '../../a2a/agent-card.js';
+import { TargetsStore, type TargetWithConfig } from '../../db/targets-store.js';
+import { emitSpaceEvent, type ProofCommEventBaseOptions } from '../events.js';
+import type { AuditLogger } from '../../gateway/audit.js';
+import { ulid } from 'ulid';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Request body for guild registration
+ */
+export interface GuildRegisterRequest {
+  /** Agent base URL (AgentCard will be fetched from this URL) */
+  url: string;
+  /** Optional display name (defaults to AgentCard.name) */
+  name?: string;
+}
+
+/**
+ * Response for successful guild registration
+ */
+export interface GuildRegisterResponse {
+  /** Registered agent ID */
+  agent_id: string;
+  /** Bearer token for subsequent API calls */
+  token: string;
+  /** Confirmed display name */
+  name: string;
+  /** Token expiration (ISO8601, optional) */
+  expires_at?: string;
+}
+
+/**
+ * Result of guild registration
+ */
+export interface GuildRegisterResult {
+  ok: boolean;
+  response?: GuildRegisterResponse;
+  error?: string;
+  statusCode?: number;
+}
+
+/**
+ * Stored token entry
+ */
+interface TokenEntry {
+  agentId: string;
+  tokenHash: string;
+  name: string;
+  createdAt: string;
+  expiresAt?: string;
+}
+
+// ============================================================================
+// Token Management
+// ============================================================================
+
+/**
+ * In-memory token store for registered agents
+ * Note: This is lost on server restart. For production, consider persisting to DB.
+ */
+const guildTokens = new Map<string, TokenEntry>();
+
+/**
+ * Secret for signing tokens (should be set via environment variable)
+ */
+const GUILD_TOKEN_SECRET = process.env.GUILD_TOKEN_SECRET || 'proofguild-dev-secret';
+
+/**
+ * Generate a random token
+ */
+function generateToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Hash a token for storage
+ */
+function hashToken(token: string): string {
+  return createHmac('sha256', GUILD_TOKEN_SECRET)
+    .update(token)
+    .digest('hex');
+}
+
+/**
+ * Validate a token and return the associated agent ID
+ */
+export function validateGuildToken(token: string): string | null {
+  const tokenHash = hashToken(token);
+  for (const [agentId, entry] of guildTokens) {
+    if (entry.tokenHash === tokenHash) {
+      // Check expiration
+      if (entry.expiresAt && new Date(entry.expiresAt) < new Date()) {
+        guildTokens.delete(agentId);
+        return null;
+      }
+      return agentId;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get all registered guild tokens (for debugging)
+ */
+export function getGuildTokenCount(): number {
+  return guildTokens.size;
+}
+
+// ============================================================================
+// Rate Limiting
+// ============================================================================
+
+/**
+ * Simple in-memory rate limiter
+ */
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 10;
+
+/**
+ * Check if rate limit is exceeded
+ */
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+
+  if (!entry || entry.resetAt < now) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return false;
+  }
+
+  entry.count++;
+  return entry.count > RATE_LIMIT_MAX_REQUESTS;
+}
+
+// ============================================================================
+// Registration Logic
+// ============================================================================
+
+export interface RegisterAgentOptions {
+  /** Targets store instance */
+  targetsStore: TargetsStore;
+  /** Audit logger for event emission */
+  auditLogger: AuditLogger;
+  /** Client IP for rate limiting */
+  clientIp: string;
+  /** Base event options */
+  baseOptions: Omit<ProofCommEventBaseOptions, 'target'>;
+  /** Allow local URLs (development only) */
+  allowLocal?: boolean;
+}
+
+/**
+ * Register an external agent with the Guild
+ *
+ * Flow:
+ * 1. Rate limit check
+ * 2. Fetch AgentCard from URL
+ * 3. Register agent in targets store
+ * 4. Generate and store token
+ * 5. Emit 'registered' event
+ * 6. Return token to agent
+ */
+export async function registerGuildAgent(
+  request: GuildRegisterRequest,
+  options: RegisterAgentOptions
+): Promise<GuildRegisterResult> {
+  const { targetsStore, auditLogger, clientIp, baseOptions, allowLocal } = options;
+
+  // Rate limit check
+  if (isRateLimited(clientIp)) {
+    return {
+      ok: false,
+      error: 'Rate limit exceeded. Try again later.',
+      statusCode: 429,
+    };
+  }
+
+  // Validate URL
+  if (!request.url || typeof request.url !== 'string') {
+    return {
+      ok: false,
+      error: 'Missing required field: url',
+      statusCode: 400,
+    };
+  }
+
+  // Normalize URL
+  const url = request.url.trim();
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    return {
+      ok: false,
+      error: 'Invalid URL: must start with http:// or https://',
+      statusCode: 400,
+    };
+  }
+
+  // Fetch AgentCard
+  const cardResult: FetchAgentCardResult = await fetchAgentCard(url, {
+    allowLocal,
+    timeout: 10_000,
+  });
+
+  if (!cardResult.ok || !cardResult.agentCard) {
+    return {
+      ok: false,
+      error: cardResult.error || 'Failed to fetch AgentCard',
+      statusCode: 422,
+    };
+  }
+
+  const agentCard = cardResult.agentCard;
+  const agentName = request.name || agentCard.name;
+
+  // Check if agent is already registered (by URL)
+  const existingTargets = targetsStore.list({ type: 'agent' });
+  for (const target of existingTargets) {
+    const config = target.config as { url?: string } | undefined;
+    if (config?.url === url) {
+      return {
+        ok: false,
+        error: 'Agent already registered with this URL',
+        statusCode: 409,
+      };
+    }
+  }
+
+  // Register agent in targets store
+  const agentId = ulid();
+  let target: TargetWithConfig;
+  try {
+    target = targetsStore.add({
+      type: 'agent',
+      protocol: 'a2a',
+      name: agentName,
+      enabled: true,
+      config: {
+        schema_version: 1,
+        url,
+        source: 'guild_register',
+        registered_at: new Date().toISOString(),
+      },
+    }, { id: agentId });
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Failed to register agent: ${err instanceof Error ? err.message : 'Unknown error'}`,
+      statusCode: 500,
+    };
+  }
+
+  // Generate token
+  const token = generateToken();
+  const tokenHash = hashToken(token);
+  const now = new Date().toISOString();
+
+  // Store token
+  guildTokens.set(agentId, {
+    agentId,
+    tokenHash,
+    name: agentName,
+    createdAt: now,
+    // No expiration for MVP
+  });
+
+  // Emit 'registered' event
+  emitSpaceEvent(
+    auditLogger,
+    'registered',
+    {
+      agent_id: agentId,
+      agent_name: agentName,
+    },
+    {
+      ...baseOptions,
+      target: agentId,
+    }
+  );
+
+  return {
+    ok: true,
+    response: {
+      agent_id: agentId,
+      token,
+      name: agentName,
+    },
+  };
+}
+
+/**
+ * Clean up expired tokens and old rate limit entries
+ */
+export function cleanupGuildTokens(): void {
+  const now = Date.now();
+
+  // Clean up expired tokens
+  for (const [agentId, entry] of guildTokens) {
+    if (entry.expiresAt && new Date(entry.expiresAt).getTime() < now) {
+      guildTokens.delete(agentId);
+    }
+  }
+
+  // Clean up old rate limit entries
+  for (const [ip, entry] of rateLimitMap) {
+    if (entry.resetAt < now) {
+      rateLimitMap.delete(ip);
+    }
+  }
+}

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -68,16 +68,31 @@ interface TokenEntry {
 // ============================================================================
 
 /**
- * API key for guild registration (required)
+ * Get API key at call time (not captured at module load)
+ * This allows setting the env var after module initialization
  */
-const GUILD_API_KEY = process.env.GUILD_API_KEY;
+function getApiKey(): string | undefined {
+  return process.env.GUILD_API_KEY;
+}
+
+/**
+ * Compute HMAC digest for timing-safe comparison
+ * Using HMAC ensures constant-length comparison regardless of input length
+ */
+function hmacDigest(value: string): Buffer {
+  return createHmac('sha256', 'api-key-comparison')
+    .update(value)
+    .digest();
+}
 
 /**
  * Validate API key from Authorization header using timing-safe comparison
+ * Uses HMAC comparison to prevent length-based timing attacks
  * @returns true if valid, false otherwise
  */
 export function validateApiKey(authHeader: string | undefined): boolean {
-  if (!GUILD_API_KEY) {
+  const apiKey = getApiKey();
+  if (!apiKey) {
     // No API key configured - reject all requests
     return false;
   }
@@ -90,21 +105,16 @@ export function validateApiKey(authHeader: string | undefined): boolean {
     return false;
   }
   const providedKey = match[1];
-  // Use timing-safe comparison to prevent timing attacks
-  if (providedKey.length !== GUILD_API_KEY.length) {
-    return false;
-  }
-  return timingSafeEqual(
-    Buffer.from(providedKey, 'utf-8'),
-    Buffer.from(GUILD_API_KEY, 'utf-8')
-  );
+  // Use HMAC comparison to ensure constant-length timing-safe check
+  // This prevents length leakage that would occur with direct length comparison
+  return timingSafeEqual(hmacDigest(providedKey), hmacDigest(apiKey));
 }
 
 /**
- * Check if API key is configured
+ * Check if API key is configured (read at call time)
  */
 export function isApiKeyConfigured(): boolean {
-  return !!GUILD_API_KEY;
+  return !!getApiKey();
 }
 
 // ============================================================================
@@ -118,20 +128,30 @@ export function isApiKeyConfigured(): boolean {
 const guildTokensByHash = new Map<string, TokenEntry>();
 
 /**
- * Secret for signing tokens (must be set via environment variable in production)
+ * Cached token secret (lazy initialization)
+ */
+let cachedTokenSecret: string | null = null;
+
+/**
+ * Get token secret at first use (deferred evaluation)
+ * This allows setting the env var after module initialization
+ * and ensures production check runs when the feature is actually used
  */
 function getTokenSecret(): string {
+  if (cachedTokenSecret !== null) {
+    return cachedTokenSecret;
+  }
   const secret = process.env.GUILD_TOKEN_SECRET;
   if (!secret) {
     if (process.env.NODE_ENV === 'production') {
       throw new Error('[ProofGuild] GUILD_TOKEN_SECRET must be set in production');
     }
-    return 'proofguild-dev-secret';
+    cachedTokenSecret = 'proofguild-dev-secret';
+  } else {
+    cachedTokenSecret = secret;
   }
-  return secret;
+  return cachedTokenSecret;
 }
-
-const GUILD_TOKEN_SECRET = getTokenSecret();
 
 /**
  * Token TTL in milliseconds (30 days)
@@ -146,10 +166,10 @@ function generateToken(): string {
 }
 
 /**
- * Hash a token for storage
+ * Hash a token for storage (uses lazy-loaded secret)
  */
 function hashToken(token: string): string {
-  return createHmac('sha256', GUILD_TOKEN_SECRET)
+  return createHmac('sha256', getTokenSecret())
     .update(token)
     .digest('hex');
 }
@@ -221,6 +241,14 @@ const LOCALHOST_HOSTNAMES = new Set([
 /**
  * Check if a URL points to an internal/private address (SSRF protection)
  * @returns true if the URL is safe (external), false if internal
+ *
+ * Note: This validates the URL string, not the resolved IP address.
+ * DNS rebinding attacks (where a hostname resolves to a private IP after validation)
+ * are not fully prevented by this check alone. fetchAgentCard has additional
+ * SSRF protection via isPrivateUrl, but for high-security deployments, consider:
+ * - HTTP client-level IP validation after DNS resolution
+ * - Network-level egress filtering
+ * - DNS pinning or resolution validation
  */
 export function isExternalUrl(urlString: string): boolean {
   try {

--- a/src/proofcomm/guild/register.ts
+++ b/src/proofcomm/guild/register.ts
@@ -198,6 +198,10 @@ function hashToken(token: string): string {
 
 /**
  * Validate a token and return the associated agent ID (O(1) lookup)
+ *
+ * Note: This function is exported for Phase 6 when external agents will
+ * authenticate to guild endpoints (e.g., join spaces, send messages).
+ * Currently, registration returns a token but no endpoint consumes it yet.
  */
 export function validateGuildToken(token: string): string | null {
   if (!token) return null;
@@ -321,6 +325,12 @@ export function isExternalUrl(urlString: string): boolean {
 
 /**
  * Simple in-memory rate limiter
+ *
+ * Note: In-memory state is not shared across processes/workers.
+ * If running behind a proxy/load balancer, ensure:
+ * - Fastify `trustProxy` is configured correctly
+ * - `x-forwarded-for` headers are parsed to get real client IP
+ * - Otherwise all requests share one rate limit bucket (the proxy IP)
  */
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute

--- a/src/proofportal/__tests__/guild.test.ts
+++ b/src/proofportal/__tests__/guild.test.ts
@@ -1,0 +1,666 @@
+/**
+ * ProofPortal - Guild tests
+ * Phase 5: ProofGuild
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcLevel,
+  getVisualState,
+  getMembershipStatus,
+  getGuildRole,
+  toGuildMember,
+  deriveGuildState,
+  createInitialState,
+  applyEvent,
+  SPEAKING_THRESHOLD_MS,
+  ACTIVE_THRESHOLD_MS,
+  type AgentState,
+  type SpaceState,
+  type PortalSseEvent,
+} from '../types.js';
+
+describe('ProofGuild - Level Calculation', () => {
+  describe('calcLevel', () => {
+    it('should return level 1 for 0 XP', () => {
+      expect(calcLevel(0)).toBe(1);
+    });
+
+    it('should return level 1 for 9 XP', () => {
+      expect(calcLevel(9)).toBe(1);
+    });
+
+    it('should return level 2 for 10 XP', () => {
+      expect(calcLevel(10)).toBe(2);
+    });
+
+    it('should return level 2 for 39 XP', () => {
+      expect(calcLevel(39)).toBe(2);
+    });
+
+    it('should return level 3 for 40 XP', () => {
+      expect(calcLevel(40)).toBe(3);
+    });
+
+    it('should return level 4 for 90 XP', () => {
+      expect(calcLevel(90)).toBe(4);
+    });
+
+    it('should return level 5 for 160 XP', () => {
+      expect(calcLevel(160)).toBe(5);
+    });
+
+    it('should handle large XP values', () => {
+      expect(calcLevel(10000)).toBe(32);
+    });
+  });
+});
+
+describe('ProofGuild - Visual State', () => {
+  describe('getVisualState', () => {
+    it('should return speaking if message within threshold', () => {
+      const now = Date.now();
+      const lastMessageAt = now - 5000; // 5 seconds ago
+      const lastSeenAt = now - 1000;
+
+      expect(getVisualState(lastMessageAt, lastSeenAt, now)).toBe('speaking');
+    });
+
+    it('should return speaking at exact threshold', () => {
+      const now = Date.now();
+      const lastMessageAt = now - SPEAKING_THRESHOLD_MS + 1;
+      const lastSeenAt = now - 1000;
+
+      expect(getVisualState(lastMessageAt, lastSeenAt, now)).toBe('speaking');
+    });
+
+    it('should return active if no recent message but recent event', () => {
+      const now = Date.now();
+      const lastMessageAt = now - 30000; // 30 seconds ago
+      const lastSeenAt = now - 5000;
+
+      expect(getVisualState(lastMessageAt, lastSeenAt, now)).toBe('active');
+    });
+
+    it('should return active with no message but recent event', () => {
+      const now = Date.now();
+      const lastSeenAt = now - 30000;
+
+      expect(getVisualState(undefined, lastSeenAt, now)).toBe('active');
+    });
+
+    it('should return idle if no recent activity', () => {
+      const now = Date.now();
+      const lastMessageAt = now - 120000; // 2 minutes ago
+      const lastSeenAt = now - 90000;
+
+      expect(getVisualState(lastMessageAt, lastSeenAt, now)).toBe('idle');
+    });
+
+    it('should return idle at exact active threshold', () => {
+      const now = Date.now();
+      const lastSeenAt = now - ACTIVE_THRESHOLD_MS;
+
+      expect(getVisualState(undefined, lastSeenAt, now)).toBe('idle');
+    });
+  });
+});
+
+describe('ProofGuild - Membership Status', () => {
+  describe('getMembershipStatus', () => {
+    it('should return active if recent event', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 5,
+        lastSeenAt: now - 30000,
+        experience: 0,
+      };
+
+      expect(getMembershipStatus(agent, now)).toBe('active');
+    });
+
+    it('should return joined if has space membership but not active', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 5,
+        lastSeenAt: now - 120000, // 2 minutes ago
+        experience: 0,
+      };
+
+      expect(getMembershipStatus(agent, now)).toBe('joined');
+    });
+
+    it('should return candidate if no space membership and not active', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(),
+        eventCount: 1,
+        lastSeenAt: now - 120000,
+        experience: 0,
+      };
+
+      expect(getMembershipStatus(agent, now)).toBe('candidate');
+    });
+  });
+});
+
+describe('ProofGuild - Guild Role', () => {
+  describe('getGuildRole', () => {
+    it('should return visitor if no space membership', () => {
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(),
+        eventCount: 0,
+        lastSeenAt: Date.now(),
+        experience: 0,
+      };
+      const spaces = new Map<string, SpaceState>();
+
+      expect(getGuildRole(agent, spaces)).toBe('visitor');
+    });
+
+    it('should return member if has space membership', () => {
+      const agent: AgentState = {
+        agentId: 'test-agent',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 1,
+        lastSeenAt: Date.now(),
+        experience: 0,
+      };
+      const spaces = new Map<string, SpaceState>();
+
+      expect(getGuildRole(agent, spaces)).toBe('member');
+    });
+  });
+});
+
+describe('ProofGuild - Guild Member Derivation', () => {
+  describe('toGuildMember', () => {
+    it('should derive guild member from agent state', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'test-agent-123',
+        traceIds: new Set(['trace-1']),
+        spaceIds: new Set(['space-1']),
+        eventCount: 10,
+        lastSeenAt: now - 5000,
+        name: 'TestBot',
+        experience: 45,
+        currentSpaceId: 'space-1',
+        currentSpaceName: 'Test Room',
+        lastMessagePreview: 'Hello world',
+        lastMessageAt: now - 2000,
+      };
+      const spaces = new Map<string, SpaceState>();
+
+      const member = toGuildMember(agent, spaces, now);
+
+      expect(member.agentId).toBe('test-agent-123');
+      expect(member.name).toBe('TestBot');
+      expect(member.level).toBe(3); // sqrt(45/10) + 1 = 3
+      expect(member.experience).toBe(45);
+      expect(member.role).toBe('member');
+      expect(member.membershipStatus).toBe('active');
+      expect(member.visualState).toBe('speaking');
+      expect(member.currentSpaceId).toBe('space-1');
+      expect(member.lastMessagePreview).toBe('Hello world');
+      expect(member.eventCount).toBe(10);
+    });
+
+    it('should use agentId as name fallback', () => {
+      const now = Date.now();
+      const agent: AgentState = {
+        agentId: 'agent-abc-123',
+        traceIds: new Set(),
+        spaceIds: new Set(),
+        eventCount: 1,
+        lastSeenAt: now - 1000,
+        experience: 0,
+      };
+      const spaces = new Map<string, SpaceState>();
+
+      const member = toGuildMember(agent, spaces, now);
+
+      expect(member.name).toBe('agent-abc-123');
+    });
+  });
+});
+
+describe('ProofGuild - Guild State Derivation', () => {
+  describe('deriveGuildState', () => {
+    it('should derive empty guild state from empty portal state', () => {
+      const state = createInitialState();
+      const now = Date.now();
+
+      const guild = deriveGuildState(state, now);
+
+      expect(guild.members.size).toBe(0);
+      expect(guild.rooms.size).toBe(0);
+    });
+
+    it('should derive guild members from agents', () => {
+      const state = createInitialState();
+      const now = Date.now();
+
+      state.agents.set('agent-1', {
+        agentId: 'agent-1',
+        name: 'Bot1',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 5,
+        lastSeenAt: now - 1000,
+        experience: 20,
+        currentSpaceId: 'space-1',
+      });
+
+      const guild = deriveGuildState(state, now);
+
+      expect(guild.members.size).toBe(1);
+      expect(guild.members.get('agent-1')?.name).toBe('Bot1');
+    });
+
+    it('should derive rooms from spaces with members', () => {
+      const state = createInitialState();
+      const now = Date.now();
+
+      state.spaces.set('space-1', {
+        spaceId: 'space-1',
+        spaceName: 'Main Hall',
+        members: new Set(['agent-1']),
+        events: [],
+        messageCount: 5,
+        lastActivityAt: now,
+      });
+
+      state.agents.set('agent-1', {
+        agentId: 'agent-1',
+        traceIds: new Set(),
+        spaceIds: new Set(['space-1']),
+        eventCount: 5,
+        lastSeenAt: now - 1000,
+        experience: 10,
+        currentSpaceId: 'space-1',
+      });
+
+      const guild = deriveGuildState(state, now);
+
+      expect(guild.rooms.size).toBe(1);
+      const room = guild.rooms.get('space-1');
+      expect(room?.spaceName).toBe('Main Hall');
+      expect(room?.memberIds).toContain('agent-1');
+    });
+  });
+});
+
+describe('ProofGuild - XP Calculation via Events', () => {
+  it('should award XP for join event', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.experience).toBe(2);
+  });
+
+  it('should award XP for message event', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        message_preview: 'Hello',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.experience).toBe(5);
+  });
+
+  it('should award XP for skill match event', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_skill',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'match',
+        agent_id: 'agent-1',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.experience).toBe(10);
+  });
+
+  it('should accumulate XP across multiple events', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // Join event
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Message event
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Another message
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 2000,
+      request_id: 'req-3',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.experience).toBe(2 + 5 + 5); // join + 2 messages
+  });
+});
+
+describe('ProofGuild - currentSpaceId Tracking', () => {
+  it('should set currentSpaceId on join', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        space_name: 'Main Room',
+        agent_id: 'agent-1',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.currentSpaceId).toBe('space-1');
+    expect(agent?.currentSpaceName).toBe('Main Room');
+  });
+
+  it('should update currentSpaceId on message', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // Join space-1
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Message in space-2
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'message',
+        space_id: 'space-2',
+        space_name: 'Side Room',
+        agent_id: 'agent-1',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.currentSpaceId).toBe('space-2');
+    expect(agent?.currentSpaceName).toBe('Side Room');
+  });
+
+  it('should clear currentSpaceId on leave from current space', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // Join
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Leave
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'left',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.currentSpaceId).toBeUndefined();
+    expect(agent?.currentSpaceName).toBeUndefined();
+  });
+
+  it('should not clear currentSpaceId when leaving different space', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // Join space-1
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'joined',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+      },
+    });
+
+    // Leave space-2 (different space)
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'left',
+        space_id: 'space-2',
+        agent_id: 'agent-1',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.currentSpaceId).toBe('space-1');
+  });
+});
+
+describe('ProofGuild - Agent Name Tracking', () => {
+  it('should extract agent_name from metadata', () => {
+    const state = createInitialState();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        agent_name: 'CoolBot',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.name).toBe('CoolBot');
+  });
+
+  it('should update name if new agent_name provided', () => {
+    const state = createInitialState();
+    const now = Date.now();
+
+    // First event with name
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        agent_id: 'agent-1',
+        agent_name: 'OldName',
+      },
+    });
+
+    // Second event with new name
+    applyEvent(state, {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now + 1000,
+      request_id: 'req-2',
+      metadata: {
+        action: 'message',
+        agent_id: 'agent-1',
+        agent_name: 'NewName',
+      },
+    });
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.name).toBe('NewName');
+  });
+});
+
+describe('ProofGuild - Message Preview Tracking', () => {
+  it('should truncate message preview to 40 chars', () => {
+    const state = createInitialState();
+    const longMessage = 'This is a very long message that exceeds 40 characters and should be truncated';
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        message_preview: longMessage,
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.lastMessagePreview?.length).toBeLessThanOrEqual(40);
+  });
+
+  it('should keep short messages intact', () => {
+    const state = createInitialState();
+    const shortMessage = 'Hello!';
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: Date.now(),
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        message_preview: shortMessage,
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.lastMessagePreview).toBe('Hello!');
+  });
+
+  it('should track lastMessageAt timestamp', () => {
+    const state = createInitialState();
+    const now = Date.now();
+    const event: PortalSseEvent = {
+      event_kind: 'proofcomm_space',
+      client_id: 'client-1',
+      ts: now,
+      request_id: 'req-1',
+      metadata: {
+        action: 'message',
+        space_id: 'space-1',
+        agent_id: 'agent-1',
+        message_preview: 'Test',
+      },
+    };
+
+    applyEvent(state, event);
+
+    const agent = state.agents.get('agent-1');
+    expect(agent?.lastMessageAt).toBe(now);
+  });
+});

--- a/src/proofportal/__tests__/guild.test.ts
+++ b/src/proofportal/__tests__/guild.test.ts
@@ -16,7 +16,6 @@ import {
   SPEAKING_THRESHOLD_MS,
   ACTIVE_THRESHOLD_MS,
   type AgentState,
-  type SpaceState,
   type PortalSseEvent,
 } from '../types.js';
 
@@ -163,9 +162,8 @@ describe('ProofGuild - Guild Role', () => {
         lastSeenAt: Date.now(),
         experience: 0,
       };
-      const spaces = new Map<string, SpaceState>();
 
-      expect(getGuildRole(agent, spaces)).toBe('visitor');
+      expect(getGuildRole(agent)).toBe('visitor');
     });
 
     it('should return member if has space membership', () => {
@@ -177,9 +175,8 @@ describe('ProofGuild - Guild Role', () => {
         lastSeenAt: Date.now(),
         experience: 0,
       };
-      const spaces = new Map<string, SpaceState>();
 
-      expect(getGuildRole(agent, spaces)).toBe('member');
+      expect(getGuildRole(agent)).toBe('member');
     });
   });
 });
@@ -201,9 +198,8 @@ describe('ProofGuild - Guild Member Derivation', () => {
         lastMessagePreview: 'Hello world',
         lastMessageAt: now - 2000,
       };
-      const spaces = new Map<string, SpaceState>();
 
-      const member = toGuildMember(agent, spaces, now);
+      const member = toGuildMember(agent, now);
 
       expect(member.agentId).toBe('test-agent-123');
       expect(member.name).toBe('TestBot');
@@ -227,9 +223,8 @@ describe('ProofGuild - Guild Member Derivation', () => {
         lastSeenAt: now - 1000,
         experience: 0,
       };
-      const spaces = new Map<string, SpaceState>();
 
-      const member = toGuildMember(agent, spaces, now);
+      const member = toGuildMember(agent, now);
 
       expect(member.name).toBe('agent-abc-123');
     });

--- a/src/proofportal/index.ts
+++ b/src/proofportal/index.ts
@@ -1,9 +1,10 @@
 /**
  * ProofPortal - Agent Communication Visualization
- * Phase 4: ProofPortal MVP
+ * Phase 5: ProofGuild
  *
  * Real-time visualization UI for ProofComm agent communication.
  * Consumes SSE events and provides read-only monitoring.
+ * Displays agents as Guild members with roles, levels, and visual states.
  *
  * Usage:
  *   import { registerPortalRoutes } from './proofportal/index.js';
@@ -18,6 +19,7 @@ export { registerPortalRoutes, type PortalRoutesOptions } from './routes.js';
 
 // Types
 export {
+  // Portal types
   type PortalState,
   type ThreadState,
   type SpaceState,
@@ -30,6 +32,22 @@ export {
   createInitialState,
   toDisplayEvent,
   applyEvent,
+  // Guild types (Phase 5)
+  type GuildRole,
+  type GuildVisualState,
+  type GuildMembershipStatus,
+  type GuildMember,
+  type GuildSpaceRoom,
+  type GuildState,
+  // Guild helpers
+  calcLevel,
+  getVisualState,
+  getMembershipStatus,
+  getGuildRole,
+  toGuildMember,
+  deriveGuildState,
+  SPEAKING_THRESHOLD_MS,
+  ACTIVE_THRESHOLD_MS,
 } from './types.js';
 
 // Templates

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -588,19 +588,21 @@ export function getSseClientScript(): string {
     var MAX_MAP_AGENTS = 50; // Cap to prevent unbounded DOM growth
     var LOBBY_SPACE_ID = '_proofguild_lobby_'; // Namespaced sentinel to avoid collision with real space IDs
 
-    const now = Date.now();
+    var now = Date.now();
 
-    // Collect rooms from spaces
-    const rooms = [];
-    const lobbyMembers = [];
+    // Build room Map for O(1) lookup by spaceId
+    var rooms = [];
+    var roomsBySpaceId = new Map();
+    var lobbyMembers = [];
 
-    // Build room list from spaces
     state.spaces.forEach(function(space) {
-      rooms.push({
+      var room = {
         spaceId: space.spaceId,
         spaceName: space.spaceName || truncateId(space.spaceId, 12),
         members: []
-      });
+      };
+      rooms.push(room);
+      roomsBySpaceId.set(space.spaceId, room);
     });
 
     // Place agents in rooms based on currentSpaceId (cap to MAX_MAP_AGENTS)
@@ -611,9 +613,9 @@ export function getSseClientScript(): string {
     for (var i = 0; i < agents.length && agentCount < MAX_MAP_AGENTS; i++) {
       var agent = agents[i];
       agentCount++;
-      const visualState = getVisualState(agent, now);
-      const level = calcLevel(agent.experience);
-      const memberData = {
+      var visualState = getVisualState(agent, now);
+      var level = calcLevel(agent.experience);
+      var memberData = {
         agentId: agent.agentId,
         name: getAgentDisplayName(agent),
         level: level,
@@ -622,7 +624,7 @@ export function getSseClientScript(): string {
       };
 
       if (agent.currentSpaceId) {
-        const room = rooms.find(function(r) { return r.spaceId === agent.currentSpaceId; });
+        var room = roomsBySpaceId.get(agent.currentSpaceId);
         if (room) {
           room.members.push(memberData);
         } else {
@@ -651,7 +653,7 @@ export function getSseClientScript(): string {
     }
 
     guildMapEl.innerHTML = rooms.map(function(room) {
-      const memberHtml = room.members.map(function(member) {
+      var memberHtml = room.members.map(function(member) {
         return '<div class="guild-map-member ' + getVisualStateClass(member.visualState) + '" ' +
           'data-agent-id="' + escapeHtml(member.agentId) + '" ' +
           'title="' + escapeHtml(member.name) + ' (' + formatLevel(member.level) + ')">' +

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -50,6 +50,8 @@ export function getSseClientScript(): string {
   const ACTIVE_THRESHOLD_MS = 60000;    // 60 seconds for 'active' state
 
   // XP values per action
+  // IMPORTANT: Keep in sync with applyEvent() in src/proofportal/types.ts
+  // These values must match the server-side XP calculation
   const XP_VALUES = {
     joined: 2,
     message: 5,

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -1,6 +1,6 @@
 /**
  * ProofPortal - SSE Client (Browser-side)
- * Phase 4: ProofPortal MVP
+ * Phase 5: ProofGuild
  *
  * This module generates inline JavaScript for browser-side SSE consumption.
  * The generated code runs in the browser to receive real-time events from Gateway.
@@ -11,6 +11,11 @@
  * - Server-side: TypeScript modules used for SSR
  * - Browser-side: Inline JavaScript with no module system
  * The functions must be kept in sync manually.
+ *
+ * Phase 5 additions:
+ * - Guild state tracking (name, XP, level, visualState)
+ * - currentSpaceId tracking for Room placement
+ * - Speaking/Active/Idle state calculation
  */
 
 /**
@@ -39,6 +44,20 @@ export function getSseClientScript(): string {
   const MAX_THREADS = 100;
   const MAX_SPACES = 50;
   const MAX_AGENTS = 100;
+
+  // Guild thresholds (Phase 5)
+  const SPEAKING_THRESHOLD_MS = 10000;  // 10 seconds for 'speaking' state
+  const ACTIVE_THRESHOLD_MS = 60000;    // 60 seconds for 'active' state
+
+  // XP values per action
+  const XP_VALUES = {
+    joined: 2,
+    message: 5,
+    match: 10,
+    context_updated: 8,
+    dispatched: 6,
+    registered: 3
+  };
 
   // State
   const state = {
@@ -80,6 +99,9 @@ export function getSseClientScript(): string {
   const agentListEl = document.getElementById('agentList');
   const threadListEl = document.getElementById('threadList');
   const spaceListEl = document.getElementById('spaceList');
+  // Guild DOM elements (Phase 5)
+  const guildPanelEl = document.getElementById('guildPanel');
+  const guildMapEl = document.getElementById('guildMap');
 
   /**
    * Update connection status display
@@ -128,6 +150,59 @@ export function getSseClientScript(): string {
       .replace(/"/g, '&quot;');
   }
 
+  // ============================================================================
+  // Guild Helper Functions (Phase 5)
+  // ============================================================================
+
+  /**
+   * Calculate level from XP
+   */
+  function calcLevel(xp) {
+    return Math.floor(Math.sqrt(xp / 10)) + 1;
+  }
+
+  /**
+   * Get visual state based on timestamps
+   */
+  function getVisualState(agent, now) {
+    if (agent.lastMessageAt && (now - agent.lastMessageAt) < SPEAKING_THRESHOLD_MS) {
+      return 'speaking';
+    }
+    if ((now - agent.lastSeenAt) < ACTIVE_THRESHOLD_MS) {
+      return 'active';
+    }
+    return 'idle';
+  }
+
+  /**
+   * Get membership status
+   */
+  function getMembershipStatus(agent, now) {
+    if ((now - agent.lastSeenAt) < ACTIVE_THRESHOLD_MS) {
+      return 'active';
+    }
+    if (agent.spaceIds.size > 0) {
+      return 'joined';
+    }
+    return 'candidate';
+  }
+
+  /**
+   * Get display name for agent
+   */
+  function getAgentDisplayName(agent) {
+    return agent.name || truncateId(agent.agentId, 12);
+  }
+
+  /**
+   * Truncate message preview for bubble display
+   */
+  function truncatePreview(str, maxLen) {
+    if (!str) return '';
+    if (str.length <= maxLen) return str;
+    return str.slice(0, maxLen - 1) + '…';
+  }
+
   /**
    * Process incoming SSE event
    */
@@ -150,7 +225,14 @@ export function getSseClientScript(): string {
           traceIds: new Set(),
           spaceIds: new Set(),
           eventCount: 0,
-          lastSeenAt: now
+          lastSeenAt: now,
+          // Guild fields (Phase 5)
+          name: null,
+          experience: 0,
+          lastMessagePreview: null,
+          lastMessageAt: null,
+          currentSpaceId: null,
+          currentSpaceName: null
         };
         state.agents.set(agentId, agent);
       }
@@ -158,6 +240,39 @@ export function getSseClientScript(): string {
       agent.lastSeenAt = now;
       if (traceId) agent.traceIds.add(traceId);
       if (spaceId) agent.spaceIds.add(spaceId);
+
+      // Guild updates (Phase 5)
+      // Extract agent_name from metadata
+      if (metadata.agent_name) {
+        agent.name = metadata.agent_name;
+      }
+
+      // Track currentSpaceId and XP based on action
+      const action = metadata.action;
+      if (action === 'joined' && spaceId) {
+        agent.currentSpaceId = spaceId;
+        agent.currentSpaceName = metadata.space_name || null;
+        agent.experience += XP_VALUES.joined || 0;
+      } else if (action === 'message' && spaceId) {
+        agent.currentSpaceId = spaceId;
+        agent.currentSpaceName = metadata.space_name || null;
+        agent.lastMessagePreview = truncatePreview(metadata.message_preview, 40);
+        agent.lastMessageAt = now;
+        agent.experience += XP_VALUES.message || 0;
+      } else if (action === 'left' && spaceId) {
+        if (agent.currentSpaceId === spaceId) {
+          agent.currentSpaceId = null;
+          agent.currentSpaceName = null;
+        }
+      } else if (action === 'match') {
+        agent.experience += XP_VALUES.match || 0;
+      } else if (action === 'context_updated') {
+        agent.experience += XP_VALUES.context_updated || 0;
+      } else if (action === 'dispatched') {
+        agent.experience += XP_VALUES.dispatched || 0;
+      } else if (action === 'registered') {
+        agent.experience += XP_VALUES.registered || 0;
+      }
     }
 
     // Update space state
@@ -212,6 +327,8 @@ export function getSseClientScript(): string {
     renderAgentList();
     renderSpaceList();
     renderThreadList();
+    renderGuildPanel();
+    renderGuildMap();
     updateEventCount();
   }
 
@@ -395,6 +512,156 @@ export function getSseClientScript(): string {
     if (header) header.textContent = state.threads.size;
   }
 
+  // ============================================================================
+  // Guild Rendering (Phase 5)
+  // ============================================================================
+
+  /**
+   * Get visual state class name
+   */
+  function getVisualStateClass(visualState) {
+    return 'visual-state-' + visualState;
+  }
+
+  /**
+   * Format level display
+   */
+  function formatLevel(level) {
+    return 'Lv.' + level;
+  }
+
+  /**
+   * Format membership status for display
+   */
+  function formatMembershipStatus(status) {
+    if (status === 'active') return 'Active';
+    if (status === 'joined') return 'Joined';
+    return 'Candidate';
+  }
+
+  /**
+   * Render Guild Panel (member list)
+   */
+  function renderGuildPanel() {
+    if (!guildPanelEl) return;
+
+    const now = Date.now();
+
+    if (state.agents.size === 0) {
+      guildPanelEl.innerHTML = '<div class="guild-empty">No guild members yet</div>';
+      return;
+    }
+
+    const agents = Array.from(state.agents.values())
+      .sort(function(a, b) { return b.lastSeenAt - a.lastSeenAt; })
+      .slice(0, 20);
+
+    guildPanelEl.innerHTML = agents.map(function(agent) {
+      const visualState = getVisualState(agent, now);
+      const membershipStatus = getMembershipStatus(agent, now);
+      const level = calcLevel(agent.experience);
+      const displayName = getAgentDisplayName(agent);
+
+      return '<div class="guild-member ' + getVisualStateClass(visualState) + '" data-agent-id="' + escapeHtml(agent.agentId) + '">' +
+        '<div class="guild-member-avatar">' + displayName.charAt(0).toUpperCase() + '</div>' +
+        '<div class="guild-member-info">' +
+          '<div class="guild-member-name">' + escapeHtml(displayName) + '</div>' +
+          '<div class="guild-member-meta">' +
+            '<span class="guild-member-level" title="Session Level (XP: ' + agent.experience + ')">Session ' + formatLevel(level) + '</span>' +
+            '<span class="guild-member-status ' + membershipStatus + '">' + formatMembershipStatus(membershipStatus) + '</span>' +
+          '</div>' +
+          '<div class="guild-member-id" title="' + escapeHtml(agent.agentId) + '">' + truncateId(agent.agentId, 16) + '</div>' +
+        '</div>' +
+        (agent.lastMessagePreview ? '<div class="guild-member-bubble">' + escapeHtml(agent.lastMessagePreview) + '</div>' : '') +
+      '</div>';
+    }).join('');
+  }
+
+  /**
+   * Render Guild Map (rooms with members)
+   */
+  function renderGuildMap() {
+    if (!guildMapEl) return;
+
+    const now = Date.now();
+
+    // Collect rooms from spaces
+    const rooms = [];
+    const lobbyMembers = [];
+
+    // Build room list from spaces
+    state.spaces.forEach(function(space) {
+      rooms.push({
+        spaceId: space.spaceId,
+        spaceName: space.spaceName || truncateId(space.spaceId, 12),
+        members: []
+      });
+    });
+
+    // Place agents in rooms based on currentSpaceId
+    state.agents.forEach(function(agent) {
+      const visualState = getVisualState(agent, now);
+      const level = calcLevel(agent.experience);
+      const memberData = {
+        agentId: agent.agentId,
+        name: getAgentDisplayName(agent),
+        level: level,
+        visualState: visualState,
+        lastMessagePreview: agent.lastMessagePreview
+      };
+
+      if (agent.currentSpaceId) {
+        const room = rooms.find(function(r) { return r.spaceId === agent.currentSpaceId; });
+        if (room) {
+          room.members.push(memberData);
+        } else {
+          // Room not found, put in lobby
+          lobbyMembers.push(memberData);
+        }
+      } else {
+        // No current space, put in lobby
+        lobbyMembers.push(memberData);
+      }
+    });
+
+    // Add lobby room if there are members
+    if (lobbyMembers.length > 0) {
+      rooms.unshift({
+        spaceId: '__lobby__',
+        spaceName: 'Lobby',
+        members: lobbyMembers
+      });
+    }
+
+    // Render rooms
+    if (rooms.length === 0) {
+      guildMapEl.innerHTML = '<div class="guild-map-empty">No rooms yet</div>';
+      return;
+    }
+
+    guildMapEl.innerHTML = rooms.map(function(room) {
+      const memberHtml = room.members.map(function(member) {
+        return '<div class="guild-map-member ' + getVisualStateClass(member.visualState) + '" ' +
+          'data-agent-id="' + escapeHtml(member.agentId) + '" ' +
+          'title="' + escapeHtml(member.name) + ' (' + formatLevel(member.level) + ')">' +
+          '<div class="guild-map-member-avatar">' + member.name.charAt(0).toUpperCase() + '</div>' +
+          '<div class="guild-map-member-name">' + escapeHtml(member.name) + '</div>' +
+          (member.visualState === 'speaking' && member.lastMessagePreview ?
+            '<div class="guild-map-bubble">' + escapeHtml(member.lastMessagePreview) + '</div>' : '') +
+        '</div>';
+      }).join('');
+
+      return '<div class="guild-map-room" data-space-id="' + escapeHtml(room.spaceId) + '">' +
+        '<div class="guild-map-room-header">' +
+          '<span class="guild-map-room-icon">' + (room.spaceId === '__lobby__' ? '🏠' : '🚪') + '</span>' +
+          '<span class="guild-map-room-name">' + escapeHtml(room.spaceName) + '</span>' +
+          '<span class="guild-map-room-count">' + room.members.length + '</span>' +
+        '</div>' +
+        '<div class="guild-map-room-members">' + memberHtml + '</div>' +
+      '</div>';
+    }).join('');
+  }
+
   /**
    * Connect to SSE stream
    */
@@ -456,6 +723,8 @@ export function getSseClientScript(): string {
   renderAgentList();
   renderSpaceList();
   renderThreadList();
+  renderGuildPanel();
+  renderGuildMap();
   connect();
 
   // Cleanup on page unload

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -583,6 +583,9 @@ export function getSseClientScript(): string {
   function renderGuildMap() {
     if (!guildMapEl) return;
 
+    var MAX_MAP_AGENTS = 50; // Cap to prevent unbounded DOM growth
+    var LOBBY_SPACE_ID = '_proofguild_lobby_'; // Namespaced sentinel to avoid collision with real space IDs
+
     const now = Date.now();
 
     // Collect rooms from spaces
@@ -598,8 +601,14 @@ export function getSseClientScript(): string {
       });
     });
 
-    // Place agents in rooms based on currentSpaceId
-    state.agents.forEach(function(agent) {
+    // Place agents in rooms based on currentSpaceId (cap to MAX_MAP_AGENTS)
+    var agentCount = 0;
+    var agents = Array.from(state.agents.values())
+      .sort(function(a, b) { return b.lastSeenAt - a.lastSeenAt; });
+
+    for (var i = 0; i < agents.length && agentCount < MAX_MAP_AGENTS; i++) {
+      var agent = agents[i];
+      agentCount++;
       const visualState = getVisualState(agent, now);
       const level = calcLevel(agent.experience);
       const memberData = {
@@ -622,12 +631,12 @@ export function getSseClientScript(): string {
         // No current space, put in lobby
         lobbyMembers.push(memberData);
       }
-    });
+    }
 
     // Add lobby room if there are members
     if (lobbyMembers.length > 0) {
       rooms.unshift({
-        spaceId: '__lobby__',
+        spaceId: LOBBY_SPACE_ID,
         spaceName: 'Lobby',
         members: lobbyMembers
       });
@@ -653,7 +662,7 @@ export function getSseClientScript(): string {
 
       return '<div class="guild-map-room" data-space-id="' + escapeHtml(room.spaceId) + '">' +
         '<div class="guild-map-room-header">' +
-          '<span class="guild-map-room-icon">' + (room.spaceId === '__lobby__' ? '🏠' : '🚪') + '</span>' +
+          '<span class="guild-map-room-icon">' + (room.spaceId === LOBBY_SPACE_ID ? '🏠' : '🚪') + '</span>' +
           '<span class="guild-map-room-name">' + escapeHtml(room.spaceName) + '</span>' +
           '<span class="guild-map-room-count">' + room.members.length + '</span>' +
         '</div>' +

--- a/src/proofportal/templates/components/GuildMap.ts
+++ b/src/proofportal/templates/components/GuildMap.ts
@@ -1,0 +1,312 @@
+/**
+ * ProofPortal - GuildMap Component
+ * Phase 5: ProofGuild
+ *
+ * Displays spaces as "rooms" with agents inside:
+ * - Lobby for agents without currentSpaceId
+ * - Room for each space with members
+ * - Visual state indicators
+ * - Speaking bubbles
+ */
+
+import { escapeHtml } from '../layout.js';
+import type { GuildVisualState } from '../../types.js';
+
+/**
+ * Room member display data
+ */
+export interface RoomMemberData {
+  agentId: string;
+  name: string;
+  level: number;
+  visualState: GuildVisualState;
+  lastMessagePreview?: string;
+}
+
+/**
+ * Room display data
+ */
+export interface RoomDisplayData {
+  spaceId: string;
+  spaceName: string;
+  isLobby: boolean;
+  members: RoomMemberData[];
+}
+
+/**
+ * Get visual state class for map member
+ */
+export function getMapVisualStateClass(state: GuildVisualState): string {
+  return `visual-state-${state}`;
+}
+
+/**
+ * Format level for map display
+ */
+export function formatMapLevel(level: number): string {
+  return `Lv.${level}`;
+}
+
+/**
+ * Truncate space ID for room header
+ */
+export function truncateSpaceIdForRoom(id: string, maxLen: number = 12): string {
+  if (id.length <= maxLen) {
+    return id;
+  }
+  return id.slice(0, maxLen - 3) + '...';
+}
+
+/**
+ * Render a room member (agent icon)
+ */
+export function renderRoomMember(member: RoomMemberData): string {
+  const initial = member.name.charAt(0).toUpperCase();
+  const isSpeaking = member.visualState === 'speaking';
+
+  return `
+    <div class="guild-map-member ${getMapVisualStateClass(member.visualState)}"
+         data-agent-id="${escapeHtml(member.agentId)}"
+         title="${escapeHtml(member.name)} (${formatMapLevel(member.level)})">
+      <div class="guild-map-member-avatar">${initial}</div>
+      <div class="guild-map-member-name">${escapeHtml(member.name)}</div>
+      ${isSpeaking && member.lastMessagePreview ? `<div class="guild-map-bubble">${escapeHtml(member.lastMessagePreview)}</div>` : ''}
+    </div>
+  `;
+}
+
+/**
+ * Render a room card
+ */
+export function renderRoomCard(room: RoomDisplayData): string {
+  const roomIcon = room.isLobby ? '🏠' : '🚪';
+  const memberCount = room.members.length;
+  const membersHtml = room.members.map(renderRoomMember).join('');
+
+  return `
+    <div class="guild-map-room ${room.isLobby ? 'lobby' : ''}" data-space-id="${escapeHtml(room.spaceId)}">
+      <div class="guild-map-room-header">
+        <span class="guild-map-room-icon">${roomIcon}</span>
+        <span class="guild-map-room-name">${escapeHtml(room.spaceName)}</span>
+        <span class="guild-map-room-count">${memberCount}</span>
+      </div>
+      <div class="guild-map-room-members">
+        ${membersHtml || '<div class="guild-map-room-empty">Empty</div>'}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for guild map
+ */
+export function renderGuildMapEmptyState(): string {
+  return `
+    <div class="guild-map-empty">
+      <div class="guild-map-empty-icon">🗺️</div>
+      <div class="guild-map-empty-text">No rooms yet</div>
+      <div class="guild-map-empty-hint">Rooms appear when spaces are created</div>
+    </div>
+  `;
+}
+
+/**
+ * Get GuildMap-specific CSS styles
+ */
+export function getGuildMapStyles(): string {
+  return `
+    /* Guild map container */
+    .guild-map-content {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 8px;
+      min-height: 200px;
+    }
+
+    /* Room card */
+    .guild-map-room {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .guild-map-room.lobby {
+      border-color: var(--accent-yellow);
+      background: rgba(210, 153, 34, 0.05);
+    }
+
+    .guild-map-room-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: var(--bg-tertiary);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .guild-map-room.lobby .guild-map-room-header {
+      background: rgba(210, 153, 34, 0.1);
+    }
+
+    .guild-map-room-icon {
+      font-size: 14px;
+    }
+
+    .guild-map-room-name {
+      flex: 1;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .guild-map-room-count {
+      background: var(--bg-primary);
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-size: 10px;
+      font-weight: 500;
+      color: var(--text-secondary);
+    }
+
+    /* Room members area */
+    .guild-map-room-members {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      padding: 12px;
+      min-height: 60px;
+    }
+
+    .guild-map-room-empty {
+      color: var(--text-tertiary);
+      font-size: 11px;
+      font-style: italic;
+      width: 100%;
+      text-align: center;
+      padding: 8px;
+    }
+
+    /* Room member (agent) */
+    .guild-map-member {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px;
+      border-radius: 8px;
+      cursor: default;
+      position: relative;
+      transition: background 0.2s;
+    }
+
+    .guild-map-member:hover {
+      background: var(--bg-tertiary);
+    }
+
+    .guild-map-member-avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: var(--accent-purple);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      font-weight: 600;
+      transition: box-shadow 0.2s;
+    }
+
+    /* Visual states for map members */
+    .guild-map-member.visual-state-speaking .guild-map-member-avatar {
+      background: var(--accent-green);
+      box-shadow: 0 0 12px rgba(63, 185, 80, 0.6);
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+
+    .guild-map-member.visual-state-active .guild-map-member-avatar {
+      background: var(--accent-blue);
+      box-shadow: 0 0 6px rgba(88, 166, 255, 0.4);
+    }
+
+    .guild-map-member.visual-state-idle .guild-map-member-avatar {
+      background: var(--accent-gray);
+      opacity: 0.6;
+    }
+
+    @keyframes pulse {
+      0%, 100% { transform: scale(1); }
+      50% { transform: scale(1.05); }
+    }
+
+    .guild-map-member-name {
+      font-size: 10px;
+      color: var(--text-secondary);
+      max-width: 60px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-align: center;
+    }
+
+    /* Speaking bubble in map */
+    .guild-map-bubble {
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-bottom: 8px;
+      background: var(--accent-green);
+      color: white;
+      padding: 6px 10px;
+      border-radius: 12px;
+      font-size: 10px;
+      max-width: 120px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+      z-index: 10;
+    }
+
+    .guild-map-bubble::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 6px solid transparent;
+      border-top-color: var(--accent-green);
+    }
+
+    /* Empty state */
+    .guild-map-empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 32px;
+      color: var(--text-secondary);
+      min-height: 200px;
+    }
+
+    .guild-map-empty-icon {
+      font-size: 40px;
+      margin-bottom: 12px;
+      opacity: 0.5;
+    }
+
+    .guild-map-empty-text {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .guild-map-empty-hint {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      margin-top: 4px;
+    }
+  `;
+}

--- a/src/proofportal/templates/components/GuildPanel.ts
+++ b/src/proofportal/templates/components/GuildPanel.ts
@@ -1,0 +1,284 @@
+/**
+ * ProofPortal - GuildPanel Component
+ * Phase 5: ProofGuild
+ *
+ * Displays guild members with:
+ * - Name and level
+ * - Visual state (speaking/active/idle)
+ * - Membership status
+ * - Agent ID (for debugging)
+ * - Last message preview bubble
+ */
+
+import { escapeHtml } from '../layout.js';
+import type { GuildVisualState, GuildMembershipStatus } from '../../types.js';
+
+/**
+ * Guild member display data
+ */
+export interface GuildMemberDisplayData {
+  agentId: string;
+  name: string;
+  level: number;
+  experience: number;
+  visualState: GuildVisualState;
+  membershipStatus: GuildMembershipStatus;
+  lastMessagePreview?: string;
+  currentSpaceName?: string;
+}
+
+/**
+ * Truncate agent ID for display
+ */
+export function truncateGuildId(id: string, maxLen: number = 16): string {
+  if (id.length <= maxLen) {
+    return id;
+  }
+  return id.slice(0, maxLen - 3) + '...';
+}
+
+/**
+ * Get visual state CSS class
+ */
+export function getVisualStateClass(state: GuildVisualState): string {
+  return `visual-state-${state}`;
+}
+
+/**
+ * Format membership status for display
+ */
+export function formatMembershipStatus(status: GuildMembershipStatus): string {
+  switch (status) {
+    case 'active':
+      return 'Active';
+    case 'joined':
+      return 'Joined';
+    case 'candidate':
+      return 'Candidate';
+    default:
+      return status;
+  }
+}
+
+/**
+ * Format level for display
+ */
+export function formatLevel(level: number): string {
+  return `Lv.${level}`;
+}
+
+/**
+ * Render a guild member card
+ */
+export function renderGuildMemberCard(member: GuildMemberDisplayData): string {
+  const initial = member.name.charAt(0).toUpperCase();
+  const displayId = truncateGuildId(member.agentId);
+  const statusClass = member.membershipStatus;
+
+  return `
+    <div class="guild-member ${getVisualStateClass(member.visualState)}" data-agent-id="${escapeHtml(member.agentId)}">
+      <div class="guild-member-avatar">${initial}</div>
+      <div class="guild-member-info">
+        <div class="guild-member-name">${escapeHtml(member.name)}</div>
+        <div class="guild-member-meta">
+          <span class="guild-member-level" title="Session Level (XP: ${member.experience})">Session ${formatLevel(member.level)}</span>
+          <span class="guild-member-status ${statusClass}">${formatMembershipStatus(member.membershipStatus)}</span>
+        </div>
+        <div class="guild-member-id" title="${escapeHtml(member.agentId)}">${escapeHtml(displayId)}</div>
+      </div>
+      ${member.lastMessagePreview ? `<div class="guild-member-bubble">${escapeHtml(member.lastMessagePreview)}</div>` : ''}
+    </div>
+  `;
+}
+
+/**
+ * Render empty state for guild panel
+ */
+export function renderGuildEmptyState(): string {
+  return `
+    <div class="guild-empty">
+      <div class="guild-empty-icon">⚔️</div>
+      <div class="guild-empty-text">No guild members yet</div>
+      <div class="guild-empty-hint">Members will appear when agents join spaces</div>
+    </div>
+  `;
+}
+
+/**
+ * Get GuildPanel-specific CSS styles
+ */
+export function getGuildPanelStyles(): string {
+  return `
+    /* Guild panel container */
+    .guild-panel-content {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 8px;
+    }
+
+    /* Guild member card */
+    .guild-member {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 10px 12px;
+      background: var(--bg-secondary);
+      border-radius: 8px;
+      border-left: 3px solid var(--border-color);
+      min-width: 220px;
+      max-width: 300px;
+      transition: border-color 0.2s, background 0.2s;
+      position: relative;
+    }
+
+    /* Visual states */
+    .guild-member.visual-state-speaking {
+      border-left-color: var(--accent-green);
+      background: rgba(63, 185, 80, 0.08);
+    }
+
+    .guild-member.visual-state-active {
+      border-left-color: var(--accent-blue);
+      background: rgba(88, 166, 255, 0.05);
+    }
+
+    .guild-member.visual-state-idle {
+      border-left-color: var(--accent-gray);
+      opacity: 0.7;
+    }
+
+    /* Avatar */
+    .guild-member-avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: var(--accent-purple);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+      font-weight: 600;
+      flex-shrink: 0;
+    }
+
+    .guild-member.visual-state-speaking .guild-member-avatar {
+      background: var(--accent-green);
+      box-shadow: 0 0 8px rgba(63, 185, 80, 0.5);
+    }
+
+    .guild-member.visual-state-active .guild-member-avatar {
+      background: var(--accent-blue);
+    }
+
+    .guild-member.visual-state-idle .guild-member-avatar {
+      background: var(--accent-gray);
+    }
+
+    /* Info section */
+    .guild-member-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .guild-member-name {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-primary);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .guild-member-meta {
+      display: flex;
+      gap: 8px;
+      margin-top: 3px;
+      font-size: 11px;
+    }
+
+    .guild-member-level {
+      color: var(--accent-yellow);
+      font-weight: 500;
+    }
+
+    .guild-member-status {
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      font-weight: 500;
+      text-transform: uppercase;
+    }
+
+    .guild-member-status.active {
+      background: rgba(63, 185, 80, 0.2);
+      color: var(--accent-green);
+    }
+
+    .guild-member-status.joined {
+      background: rgba(88, 166, 255, 0.2);
+      color: var(--accent-blue);
+    }
+
+    .guild-member-status.candidate {
+      background: rgba(139, 148, 158, 0.2);
+      color: var(--accent-gray);
+    }
+
+    .guild-member-id {
+      margin-top: 2px;
+      font-size: 9px;
+      color: var(--text-tertiary);
+      font-family: monospace;
+      opacity: 0.7;
+    }
+
+    /* Message bubble */
+    .guild-member-bubble {
+      position: absolute;
+      top: -8px;
+      right: 12px;
+      background: var(--bg-primary);
+      border: 1px solid var(--border-color);
+      border-radius: 8px;
+      padding: 4px 8px;
+      font-size: 10px;
+      color: var(--text-secondary);
+      max-width: 160px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    }
+
+    .guild-member.visual-state-speaking .guild-member-bubble {
+      background: var(--accent-green);
+      color: white;
+      border-color: var(--accent-green);
+    }
+
+    /* Empty state */
+    .guild-empty {
+      text-align: center;
+      padding: 24px;
+      color: var(--text-secondary);
+    }
+
+    .guild-empty-icon {
+      font-size: 32px;
+      margin-bottom: 8px;
+    }
+
+    .guild-empty-text {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .guild-empty-hint {
+      font-size: 11px;
+      color: var(--text-tertiary);
+      margin-top: 4px;
+    }
+  `;
+}

--- a/src/proofportal/templates/components/index.ts
+++ b/src/proofportal/templates/components/index.ts
@@ -41,3 +41,28 @@ export {
   renderSpaceEmptyState,
   getSpaceViewStyles,
 } from './SpaceView.js';
+
+// GuildPanel (Phase 5)
+export {
+  type GuildMemberDisplayData,
+  truncateGuildId,
+  getVisualStateClass,
+  formatMembershipStatus,
+  formatLevel,
+  renderGuildMemberCard,
+  renderGuildEmptyState,
+  getGuildPanelStyles,
+} from './GuildPanel.js';
+
+// GuildMap (Phase 5)
+export {
+  type RoomMemberData,
+  type RoomDisplayData,
+  getMapVisualStateClass,
+  formatMapLevel,
+  truncateSpaceIdForRoom,
+  renderRoomMember,
+  renderRoomCard,
+  renderGuildMapEmptyState,
+  getGuildMapStyles,
+} from './GuildMap.js';

--- a/src/proofportal/templates/dashboard.ts
+++ b/src/proofportal/templates/dashboard.ts
@@ -1,6 +1,6 @@
 /**
  * ProofPortal - Dashboard template
- * Phase 4: ProofPortal MVP
+ * Phase 5: ProofGuild
  */
 
 import { renderLayout, escapeHtml } from './layout.js';
@@ -18,46 +18,78 @@ export interface DashboardOptions {
  */
 export function renderDashboard(options: DashboardOptions): string {
   const content = `
-  <main class="main">
-    <!-- Left Panel: Agents -->
-    <div class="panel">
-      <div class="panel-header">
-        Agents <span class="panel-count">0</span>
+  <main class="main-guild">
+    <!-- Left Column: Guild Map + Agents -->
+    <div class="panel-column left-column">
+      <!-- Guild Map Panel -->
+      <div class="panel guild-map-panel">
+        <div class="panel-header">
+          Guild Map <span class="panel-count">0</span>
+        </div>
+        <div class="panel-content guild-map-content" id="guildMap">
+          <div class="guild-map-empty">
+            <div class="guild-map-empty-icon">🗺️</div>
+            <div class="guild-map-empty-text">No rooms yet</div>
+            <div class="guild-map-empty-hint">Rooms appear when spaces are created</div>
+          </div>
+        </div>
       </div>
-      <div class="panel-content" id="agentList">
-        <div class="empty-state">
-          <div class="empty-state-icon">👤</div>
-          Waiting for events...
+
+      <!-- Agents Panel (legacy) -->
+      <div class="panel agents-panel">
+        <div class="panel-header">
+          Agents <span class="panel-count">0</span>
+        </div>
+        <div class="panel-content" id="agentList">
+          <div class="empty-state">
+            <div class="empty-state-icon">👤</div>
+            Waiting for events...
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Center Panel: Threads -->
-    <div class="panel">
-      <div class="panel-header">
-        Threads <span class="panel-count">0</span>
-      </div>
-      <div class="panel-content" id="threadList">
-        <div class="empty-state">
-          <div class="empty-state-icon">🧵</div>
-          Waiting for events...
+    <!-- Center Column: Threads -->
+    <div class="panel-column center-column">
+      <div class="panel">
+        <div class="panel-header">
+          Threads <span class="panel-count">0</span>
+        </div>
+        <div class="panel-content" id="threadList">
+          <div class="empty-state">
+            <div class="empty-state-icon">🧵</div>
+            Waiting for events...
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Right Panel: Spaces -->
-    <div class="panel">
-      <div class="panel-header">
-        Spaces <span class="panel-count">0</span>
-      </div>
-      <div class="panel-content" id="spaceList">
-        <div class="empty-state">
-          <div class="empty-state-icon">🏠</div>
-          Waiting for events...
+    <!-- Right Column: Spaces -->
+    <div class="panel-column right-column">
+      <div class="panel">
+        <div class="panel-header">
+          Spaces <span class="panel-count">0</span>
+        </div>
+        <div class="panel-content" id="spaceList">
+          <div class="empty-state">
+            <div class="empty-state-icon">🏠</div>
+            Waiting for events...
+          </div>
         </div>
       </div>
     </div>
   </main>
+
+  <!-- Guild Panel (bottom bar) -->
+  <section class="guild-panel-bar">
+    <div class="guild-panel-header">
+      <span class="guild-panel-title">⚔️ Guild Members</span>
+      <span class="guild-panel-hint">Session XP only</span>
+    </div>
+    <div class="guild-panel-content" id="guildPanel">
+      <div class="guild-empty">No guild members yet</div>
+    </div>
+  </section>
 
   <footer class="stats-bar">
     <div class="stat">
@@ -72,7 +104,7 @@ export function renderDashboard(options: DashboardOptions): string {
   `;
 
   return renderLayout({
-    title: 'ProofPortal - Agent Communication',
+    title: 'ProofPortal - Guild Communication',
     content,
     scripts: getSseClientScript(),
   });

--- a/src/proofportal/templates/layout.ts
+++ b/src/proofportal/templates/layout.ts
@@ -6,6 +6,8 @@
 import { getAgentListStyles } from './components/AgentList.js';
 import { getThreadPanelStyles } from './components/ThreadPanel.js';
 import { getSpaceViewStyles } from './components/SpaceView.js';
+import { getGuildPanelStyles } from './components/GuildPanel.js';
+import { getGuildMapStyles } from './components/GuildMap.js';
 
 /**
  * Escape HTML special characters
@@ -276,6 +278,83 @@ export function getPortalStyles(): string {
       opacity: 0.5;
     }
 
+    /* Guild layout (Phase 5) */
+    .main-guild {
+      display: grid;
+      grid-template-columns: 280px 1fr 320px;
+      gap: 1px;
+      background: var(--border-color);
+      min-height: calc(100vh - 180px);
+    }
+
+    .panel-column {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      background: var(--border-color);
+    }
+
+    .panel-column .panel {
+      flex: 1;
+      min-height: 0;
+    }
+
+    .left-column .guild-map-panel {
+      flex: 2;
+    }
+
+    .left-column .agents-panel {
+      flex: 1;
+      max-height: 200px;
+    }
+
+    .center-column .panel,
+    .right-column .panel {
+      height: 100%;
+    }
+
+    /* Guild panel bar (bottom) */
+    .guild-panel-bar {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border-color);
+      max-height: 120px;
+      overflow: hidden;
+    }
+
+    .guild-panel-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 16px;
+      background: var(--bg-tertiary);
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .guild-panel-title {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .guild-panel-hint {
+      font-size: 10px;
+      color: var(--text-tertiary);
+      font-style: italic;
+    }
+
+    .guild-panel-content {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 8px 16px;
+      overflow-x: auto;
+    }
+
+    /* CSS variable for text-tertiary */
+    :root {
+      --text-tertiary: #6e7681;
+    }
+
     /* Stats bar */
     .stats-bar {
       display: flex;
@@ -314,7 +393,8 @@ export function getPortalStyles(): string {
  * Get all component styles combined
  */
 export function getComponentStyles(): string {
-  return getAgentListStyles() + getThreadPanelStyles() + getSpaceViewStyles();
+  return getAgentListStyles() + getThreadPanelStyles() + getSpaceViewStyles() +
+    getGuildPanelStyles() + getGuildMapStyles();
 }
 
 /**

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -77,11 +77,15 @@ export interface ProofCommMetadata {
 
 /**
  * Guild role derived from Space membership
+ *
+ * Note: 'moderator' and 'observer' are reserved for future phases when
+ * Space membership includes role information. Currently getGuildRole()
+ * only returns 'member' or 'visitor' based on Space presence.
  */
 export type GuildRole =
-  | 'moderator'   // Space moderator
+  | 'moderator'   // Space moderator (future)
   | 'member'      // Space member
-  | 'observer'    // Space observer
+  | 'observer'    // Space observer (future)
   | 'visitor';    // No space membership
 
 /**
@@ -361,7 +365,8 @@ export function applyEvent(state: PortalState, event: PortalSseEvent): void {
     agent.name = metadata.agent_name;
   }
 
-  // Track currentSpaceId based on join/message/left
+  // Track currentSpaceId and award XP based on action
+  // IMPORTANT: Keep XP values in sync with XP_VALUES in src/proofportal/sse-client.ts
   if (display.action === 'joined' && display.spaceId) {
     agent.currentSpaceId = display.spaceId;
     agent.currentSpaceName = display.spaceName ?? undefined;

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -447,10 +447,9 @@ export function getMembershipStatus(
 
 /**
  * Get highest role from space membership
- * Note: This requires SpaceState to track roles, which is a simplification.
- * For now, we return 'member' for any space membership.
+ * For MVP, we return 'member' for any space membership.
  */
-export function getGuildRole(agent: AgentState, spaces: Map<string, SpaceState>): GuildRole {
+export function getGuildRole(agent: AgentState): GuildRole {
   if (agent.spaceIds.size === 0) {
     return 'visitor';
   }
@@ -464,13 +463,12 @@ export function getGuildRole(agent: AgentState, spaces: Map<string, SpaceState>)
  */
 export function toGuildMember(
   agent: AgentState,
-  spaces: Map<string, SpaceState>,
   now: number
 ): GuildMember {
   return {
     agentId: agent.agentId,
     name: agent.name ?? agent.agentId,
-    role: getGuildRole(agent, spaces),
+    role: getGuildRole(agent),
     membershipStatus: getMembershipStatus(agent, now),
     level: calcLevel(agent.experience),
     experience: agent.experience,
@@ -492,7 +490,7 @@ export function deriveGuildState(state: PortalState, now: number): GuildState {
 
   // Derive members from agents
   for (const agent of state.agents.values()) {
-    members.set(agent.agentId, toGuildMember(agent, state.spaces, now));
+    members.set(agent.agentId, toGuildMember(agent, now));
   }
 
   // Derive rooms from spaces

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -214,6 +214,10 @@ export interface AgentState {
 
 /**
  * Portal state root
+ *
+ * Note: Guild state is not stored here. Use deriveGuildState() as a pure
+ * projection function when guild data is needed. This avoids stale state
+ * since deriveGuildState computes the guild view from current agents/spaces.
  */
 export interface PortalState {
   /** Events grouped by trace_id */
@@ -228,8 +232,6 @@ export interface PortalState {
   lastEventTs: number;
   /** Total event count */
   eventCount: number;
-  /** Phase 5: Guild derived state */
-  guild: GuildState;
 }
 
 /**
@@ -243,10 +245,6 @@ export function createInitialState(): PortalState {
     connected: false,
     lastEventTs: 0,
     eventCount: 0,
-    guild: {
-      members: new Map(),
-      rooms: new Map(),
-    },
   };
 }
 
@@ -388,6 +386,8 @@ export function applyEvent(state: PortalState, event: PortalSseEvent): void {
     agent.experience += 8; // XP for document context update
   } else if (display.action === 'dispatched') {
     agent.experience += 6; // XP for route dispatch
+  } else if (display.action === 'registered') {
+    agent.experience += 3; // XP for guild registration
   }
 
   // Update global state

--- a/src/proofportal/types.ts
+++ b/src/proofportal/types.ts
@@ -1,9 +1,12 @@
 /**
  * ProofPortal - Type definitions
- * Phase 4: ProofPortal MVP
+ * Phase 5: ProofGuild
  *
  * State management types for real-time agent communication visualization.
  * State keys follow vault 3040 specification: trace_id / space_id / agent_id
+ *
+ * ProofGuild extends ProofPortal to treat agents as guild members with
+ * roles, levels, and visual states.
  */
 
 import type { GatewayEventKind } from '../db/types.js';
@@ -29,7 +32,9 @@ export type ProofCommAction =
   // document
   | 'activated' | 'deactivated' | 'context_updated'
   // route
-  | 'resolved' | 'dispatched';
+  | 'resolved' | 'dispatched'
+  // guild (Phase 5)
+  | 'registered';
 
 /**
  * SSE event data received from Gateway
@@ -65,6 +70,81 @@ export interface ProofCommMetadata {
   recipient_count?: number;
   failed_count?: number;
 }
+
+// ============================================================================
+// Guild Types (Phase 5: ProofGuild)
+// ============================================================================
+
+/**
+ * Guild role derived from Space membership
+ */
+export type GuildRole =
+  | 'moderator'   // Space moderator
+  | 'member'      // Space member
+  | 'observer'    // Space observer
+  | 'visitor';    // No space membership
+
+/**
+ * Visual state for guild members
+ */
+export type GuildVisualState =
+  | 'speaking'    // Message within last 10 seconds
+  | 'active'      // Event within last 60 seconds
+  | 'idle';       // Otherwise
+
+/**
+ * Membership status for guild members
+ * Note: 'joined' is used instead of 'member' to avoid confusion with GuildRole
+ */
+export type GuildMembershipStatus =
+  | 'active'      // Recent events (UI: "Active")
+  | 'joined'      // Space membership (UI: "Joined")
+  | 'candidate';  // Registered only (UI: "Candidate")
+
+/**
+ * Guild member representation for UI
+ */
+export interface GuildMember {
+  agentId: string;
+  /** Display name (agent_name from events, or agentId as fallback) */
+  name: string;
+  role: GuildRole;
+  membershipStatus: GuildMembershipStatus;
+  /** Session-only level (resets on page reload) */
+  level: number;
+  /** Session-only experience points */
+  experience: number;
+  /** Current space (last join/message space) */
+  currentSpaceId?: string;
+  currentSpaceName?: string;
+  visualState: GuildVisualState;
+  /** Truncated to 40 chars for bubble display */
+  lastMessagePreview?: string;
+  lastActiveAt?: number;
+  eventCount: number;
+}
+
+/**
+ * Space as a Guild "room" for visualization
+ */
+export interface GuildSpaceRoom {
+  spaceId: string;
+  spaceName: string;
+  /** Agent IDs currently in this room */
+  memberIds: string[];
+}
+
+/**
+ * Guild derived state (computed from PortalState)
+ */
+export interface GuildState {
+  members: Map<string, GuildMember>;
+  rooms: Map<string, GuildSpaceRoom>;
+}
+
+// ============================================================================
+// Portal Event Types
+// ============================================================================
 
 /**
  * Display-friendly event for UI rendering
@@ -109,6 +189,7 @@ export interface SpaceState {
 
 /**
  * Agent state - activity grouped by agent_id
+ * Extended in Phase 5 for Guild support
  */
 export interface AgentState {
   agentId: string;
@@ -116,6 +197,19 @@ export interface AgentState {
   spaceIds: Set<string>;
   eventCount: number;
   lastSeenAt: number;
+  // Phase 5: Guild fields
+  /** Agent name from event metadata */
+  name?: string;
+  /** Last message preview for bubble display */
+  lastMessagePreview?: string;
+  /** Timestamp of last message (for speaking state) */
+  lastMessageAt?: number;
+  /** Current space ID (last join/message space) */
+  currentSpaceId?: string;
+  /** Current space name */
+  currentSpaceName?: string;
+  /** Session XP (not persisted) */
+  experience: number;
 }
 
 /**
@@ -134,6 +228,8 @@ export interface PortalState {
   lastEventTs: number;
   /** Total event count */
   eventCount: number;
+  /** Phase 5: Guild derived state */
+  guild: GuildState;
 }
 
 /**
@@ -147,6 +243,10 @@ export function createInitialState(): PortalState {
     connected: false,
     lastEventTs: 0,
     eventCount: 0,
+    guild: {
+      members: new Map(),
+      rooms: new Map(),
+    },
   };
 }
 
@@ -243,6 +343,7 @@ export function applyEvent(state: PortalState, event: PortalSseEvent): void {
       spaceIds: new Set(),
       eventCount: 0,
       lastSeenAt: now,
+      experience: 0,
     };
     state.agents.set(agentId, agent);
   }
@@ -255,7 +356,160 @@ export function applyEvent(state: PortalState, event: PortalSseEvent): void {
     agent.spaceIds.add(display.spaceId);
   }
 
+  // Phase 5: Guild fields
+  // Extract agent_name from metadata
+  const metadata = event.metadata;
+  if (metadata?.agent_name) {
+    agent.name = metadata.agent_name;
+  }
+
+  // Track currentSpaceId based on join/message/left
+  if (display.action === 'joined' && display.spaceId) {
+    agent.currentSpaceId = display.spaceId;
+    agent.currentSpaceName = display.spaceName ?? undefined;
+    agent.experience += 2; // XP for joining
+  } else if (display.action === 'message' && display.spaceId) {
+    agent.currentSpaceId = display.spaceId;
+    agent.currentSpaceName = display.spaceName ?? undefined;
+    agent.lastMessagePreview = display.preview
+      ? display.preview.slice(0, 40)
+      : undefined;
+    agent.lastMessageAt = now;
+    agent.experience += 5; // XP for message
+  } else if (display.action === 'left' && display.spaceId) {
+    // Clear currentSpaceId if leaving current space
+    if (agent.currentSpaceId === display.spaceId) {
+      agent.currentSpaceId = undefined;
+      agent.currentSpaceName = undefined;
+    }
+  } else if (display.action === 'match') {
+    agent.experience += 10; // XP for skill match
+  } else if (display.action === 'context_updated') {
+    agent.experience += 8; // XP for document context update
+  } else if (display.action === 'dispatched') {
+    agent.experience += 6; // XP for route dispatch
+  }
+
   // Update global state
   state.lastEventTs = now;
   state.eventCount++;
+}
+
+// ============================================================================
+// Guild Helper Functions
+// ============================================================================
+
+/**
+ * Calculate level from XP
+ * Level 1 at 0 XP, Level 2 at 10 XP, etc.
+ */
+export function calcLevel(xp: number): number {
+  return Math.floor(Math.sqrt(xp / 10)) + 1;
+}
+
+/** Speaking threshold: 10 seconds */
+export const SPEAKING_THRESHOLD_MS = 10_000;
+/** Active threshold: 60 seconds */
+export const ACTIVE_THRESHOLD_MS = 60_000;
+
+/**
+ * Determine visual state based on timestamps
+ */
+export function getVisualState(
+  lastMessageAt: number | undefined,
+  lastSeenAt: number,
+  now: number
+): GuildVisualState {
+  if (lastMessageAt && now - lastMessageAt < SPEAKING_THRESHOLD_MS) {
+    return 'speaking';
+  }
+  if (now - lastSeenAt < ACTIVE_THRESHOLD_MS) {
+    return 'active';
+  }
+  return 'idle';
+}
+
+/**
+ * Determine membership status based on activity and space membership
+ */
+export function getMembershipStatus(
+  agent: AgentState,
+  now: number
+): GuildMembershipStatus {
+  if (now - agent.lastSeenAt < ACTIVE_THRESHOLD_MS) {
+    return 'active';
+  }
+  if (agent.spaceIds.size > 0) {
+    return 'joined';
+  }
+  return 'candidate';
+}
+
+/**
+ * Get highest role from space membership
+ * Note: This requires SpaceState to track roles, which is a simplification.
+ * For now, we return 'member' for any space membership.
+ */
+export function getGuildRole(agent: AgentState, spaces: Map<string, SpaceState>): GuildRole {
+  if (agent.spaceIds.size === 0) {
+    return 'visitor';
+  }
+  // For MVP, assume 'member' role for any space membership
+  // Full role tracking would require storing membership role in SpaceState
+  return 'member';
+}
+
+/**
+ * Derive GuildMember from AgentState
+ */
+export function toGuildMember(
+  agent: AgentState,
+  spaces: Map<string, SpaceState>,
+  now: number
+): GuildMember {
+  return {
+    agentId: agent.agentId,
+    name: agent.name ?? agent.agentId,
+    role: getGuildRole(agent, spaces),
+    membershipStatus: getMembershipStatus(agent, now),
+    level: calcLevel(agent.experience),
+    experience: agent.experience,
+    currentSpaceId: agent.currentSpaceId,
+    currentSpaceName: agent.currentSpaceName,
+    visualState: getVisualState(agent.lastMessageAt, agent.lastSeenAt, now),
+    lastMessagePreview: agent.lastMessagePreview,
+    lastActiveAt: agent.lastSeenAt,
+    eventCount: agent.eventCount,
+  };
+}
+
+/**
+ * Derive full GuildState from PortalState
+ */
+export function deriveGuildState(state: PortalState, now: number): GuildState {
+  const members = new Map<string, GuildMember>();
+  const rooms = new Map<string, GuildSpaceRoom>();
+
+  // Derive members from agents
+  for (const agent of state.agents.values()) {
+    members.set(agent.agentId, toGuildMember(agent, state.spaces, now));
+  }
+
+  // Derive rooms from spaces
+  for (const space of state.spaces.values()) {
+    const memberIds: string[] = [];
+    // Find agents whose currentSpaceId matches this space
+    for (const member of members.values()) {
+      if (member.currentSpaceId === space.spaceId) {
+        memberIds.push(member.agentId);
+      }
+    }
+    rooms.set(space.spaceId, {
+      spaceId: space.spaceId,
+      spaceName: space.spaceName ?? space.spaceId,
+      memberIds,
+    });
+  }
+
+  return { members, rooms };
 }


### PR DESCRIPTION
## Summary

- Implement ProofGuild, a logical layer treating agents as guild members with roles, levels, and visual states
- Add self-registration API for external agents (`POST /proofcomm/guild/register`)
- Add XP/Level system (session-only, calculated client-side)
- Add visual states: speaking (10s), active (60s), idle
- Add GuildMap component showing rooms with agent avatars and speaking bubbles
- Add GuildPanel component showing member list with levels and status

## Design Principles

| Principle | Description |
|-----------|-------------|
| PG1 | ProofGuild is a logical layer (not UI name) |
| PG2 | Membership derived from existing data (no new DB) |
| PG3 | Portal is derived view (not source-of-truth) |
| PG4 | Self-registration API for external agents |
| PG5 | XP/Level calculated client-side (session-only) |

## Files Changed

| File | Changes |
|------|---------|
| `src/proofcomm/guild/register.ts` | Self-registration API with rate limiting |
| `src/proofcomm/guild/index.ts` | Module exports |
| `src/proofcomm/events.ts` | Added 'registered' action |
| `src/gateway/proofcommProxy.ts` | Registration route |
| `src/proofportal/types.ts` | Guild types and helpers |
| `src/proofportal/sse-client.ts` | Guild UI rendering |
| `src/proofportal/templates/components/GuildPanel.ts` | Member list component |
| `src/proofportal/templates/components/GuildMap.ts` | Room map component |
| `src/proofportal/templates/dashboard.ts` | Guild UI integration |
| `src/proofportal/templates/layout.ts` | Guild styles |

## Test plan

- [x] All 2444 tests pass (41 new Guild tests)
- [x] Build succeeds
- [ ] Manual test: Portal displays Guild UI
- [ ] Manual test: External agent can self-register

🤖 Generated with [Claude Code](https://claude.com/claude-code)