### PR TITLE
feat(proofportal): Message bubble display on broadcast (#133)

### DIFF
--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -48,7 +48,7 @@ export function getSseClientScript(): string {
   // Guild thresholds (Phase 5)
   const SPEAKING_THRESHOLD_MS = 10000;  // 10 seconds for 'speaking' state
   const ACTIVE_THRESHOLD_MS = 60000;    // 60 seconds for 'active' state
-  const SPEAKING_EXPIRY_BUFFER_MS = 100; // Buffer to ensure state change before re-render
+  const SPEAKING_EXPIRY_BUFFER_MS = 500; // Buffer to ensure state change before re-render (robust under load)
 
   // XP values per action
   // IMPORTANT: Keep in sync with applyEvent() in src/proofportal/types.ts
@@ -760,8 +760,8 @@ export function getSseClientScript(): string {
   renderGuildMap();
   connect();
 
-  // Cleanup on page unload
-  window.addEventListener('beforeunload', function() {
+  // Cleanup on page unload (pagehide is more reliable than beforeunload on mobile)
+  window.addEventListener('pagehide', function() {
     if (eventSource) {
       eventSource.close();
     }

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -274,6 +274,8 @@ export function getSseClientScript(): string {
         // Use per-agent timer to handle multiple agents speaking simultaneously
         const existingTimer = speakingExpiryTimers.get(agentId);
         if (existingTimer) clearTimeout(existingTimer);
+        // Cancel any in-progress fade-out animation to prevent double bubble
+        leavingBubbles.delete(agentId);
         speakingExpiryTimers.set(agentId, setTimeout(function() {
           speakingExpiryTimers.delete(agentId);
           // Add to leavingBubbles for fade-out animation
@@ -298,6 +300,8 @@ export function getSseClientScript(): string {
           clearTimeout(leftTimer);
           speakingExpiryTimers.delete(agentId);
         }
+        // Clear any in-progress fade-out animation
+        leavingBubbles.delete(agentId);
       } else if (action === 'match') {
         agent.experience += XP_VALUES.match || 0;
       } else if (action === 'context_updated') {

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -80,6 +80,10 @@ export function getSseClientScript(): string {
   // Per-agent timers for re-rendering when speaking state expires
   const speakingExpiryTimers = new Map();
 
+  // Agents with bubbles currently fading out (for fade-out animation)
+  const leavingBubbles = new Set();
+  const BUBBLE_FADE_DURATION_MS = 300;
+
   /**
    * Evict oldest entries from a Map to maintain size limit (LRU)
    * Entries are evicted based on lastActivityAt or lastSeenAt field
@@ -272,8 +276,16 @@ export function getSseClientScript(): string {
         if (existingTimer) clearTimeout(existingTimer);
         speakingExpiryTimers.set(agentId, setTimeout(function() {
           speakingExpiryTimers.delete(agentId);
+          // Add to leavingBubbles for fade-out animation
+          leavingBubbles.add(agentId);
           renderGuildPanel();
           renderGuildMap();
+          // After fade animation completes, remove and re-render
+          setTimeout(function() {
+            leavingBubbles.delete(agentId);
+            renderGuildPanel();
+            renderGuildMap();
+          }, BUBBLE_FADE_DURATION_MS);
         }, SPEAKING_THRESHOLD_MS + SPEAKING_EXPIRY_BUFFER_MS));
       } else if (action === 'left' && spaceId) {
         if (agent.currentSpaceId === spaceId) {
@@ -595,6 +607,7 @@ export function getSseClientScript(): string {
           '<div class="guild-member-id" title="' + escapeHtml(agent.agentId) + '">' + truncateId(agent.agentId, 16) + '</div>' +
         '</div>' +
         (visualState === 'speaking' && agent.lastMessagePreview ? '<div class="guild-member-bubble">' + escapeHtml(agent.lastMessagePreview) + '</div>' : '') +
+        (leavingBubbles.has(agent.agentId) && agent.lastMessagePreview ? '<div class="guild-member-bubble bubble-leaving">' + escapeHtml(agent.lastMessagePreview) + '</div>' : '') +
       '</div>';
     }).join('');
   }
@@ -681,6 +694,8 @@ export function getSseClientScript(): string {
           '<div class="guild-map-member-name">' + escapeHtml(member.name) + '</div>' +
           (member.visualState === 'speaking' && member.lastMessagePreview ?
             '<div class="guild-map-bubble">' + escapeHtml(member.lastMessagePreview) + '</div>' : '') +
+          (leavingBubbles.has(member.agentId) && member.lastMessagePreview ?
+            '<div class="guild-map-bubble bubble-leaving">' + escapeHtml(member.lastMessagePreview) + '</div>' : '') +
         '</div>';
       }).join('');
 
@@ -770,6 +785,8 @@ export function getSseClientScript(): string {
       clearTimeout(timer);
     });
     speakingExpiryTimers.clear();
+    // Clear leaving bubbles tracking
+    leavingBubbles.clear();
   });
 })();
 `;

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -76,6 +76,9 @@ export function getSseClientScript(): string {
   const MAX_RECONNECT_ATTEMPTS = 10;
   const RECONNECT_DELAY = 3000;
 
+  // Timer for re-rendering when speaking state expires
+  let speakingExpiryTimer = null;
+
   /**
    * Evict oldest entries from a Map to maintain size limit (LRU)
    * Entries are evicted based on lastActivityAt or lastSeenAt field
@@ -261,6 +264,13 @@ export function getSseClientScript(): string {
         agent.lastMessagePreview = truncatePreview(metadata.message_preview, 40);
         agent.lastMessageAt = now;
         agent.experience += XP_VALUES.message || 0;
+
+        // Schedule re-render when speaking state expires (for bubble fade-out)
+        if (speakingExpiryTimer) clearTimeout(speakingExpiryTimer);
+        speakingExpiryTimer = setTimeout(function() {
+          renderGuildPanel();
+          renderGuildMap();
+        }, SPEAKING_THRESHOLD_MS + 100); // Small buffer to ensure state change
       } else if (action === 'left' && spaceId) {
         if (agent.currentSpaceId === spaceId) {
           agent.currentSpaceId = null;

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -76,8 +76,8 @@ export function getSseClientScript(): string {
   const MAX_RECONNECT_ATTEMPTS = 10;
   const RECONNECT_DELAY = 3000;
 
-  // Timer for re-rendering when speaking state expires
-  let speakingExpiryTimer = null;
+  // Per-agent timers for re-rendering when speaking state expires
+  const speakingExpiryTimers = new Map();
 
   /**
    * Evict oldest entries from a Map to maintain size limit (LRU)
@@ -266,11 +266,14 @@ export function getSseClientScript(): string {
         agent.experience += XP_VALUES.message || 0;
 
         // Schedule re-render when speaking state expires (for bubble fade-out)
-        if (speakingExpiryTimer) clearTimeout(speakingExpiryTimer);
-        speakingExpiryTimer = setTimeout(function() {
+        // Use per-agent timer to handle multiple agents speaking simultaneously
+        var existingTimer = speakingExpiryTimers.get(agentId);
+        if (existingTimer) clearTimeout(existingTimer);
+        speakingExpiryTimers.set(agentId, setTimeout(function() {
+          speakingExpiryTimers.delete(agentId);
           renderGuildPanel();
           renderGuildMap();
-        }, SPEAKING_THRESHOLD_MS + 100); // Small buffer to ensure state change
+        }, SPEAKING_THRESHOLD_MS + 100)); // Small buffer to ensure state change
       } else if (action === 'left' && spaceId) {
         if (agent.currentSpaceId === spaceId) {
           agent.currentSpaceId = null;
@@ -584,7 +587,7 @@ export function getSseClientScript(): string {
           '</div>' +
           '<div class="guild-member-id" title="' + escapeHtml(agent.agentId) + '">' + truncateId(agent.agentId, 16) + '</div>' +
         '</div>' +
-        (agent.lastMessagePreview ? '<div class="guild-member-bubble">' + escapeHtml(agent.lastMessagePreview) + '</div>' : '') +
+        (visualState === 'speaking' && agent.lastMessagePreview ? '<div class="guild-member-bubble">' + escapeHtml(agent.lastMessagePreview) + '</div>' : '') +
       '</div>';
     }).join('');
   }
@@ -755,6 +758,11 @@ export function getSseClientScript(): string {
     if (eventSource) {
       eventSource.close();
     }
+    // Clear all speaking expiry timers
+    speakingExpiryTimers.forEach(function(timer) {
+      clearTimeout(timer);
+    });
+    speakingExpiryTimers.clear();
   });
 })();
 `;

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -268,7 +268,7 @@ export function getSseClientScript(): string {
 
         // Schedule re-render when speaking state expires (for bubble fade-out)
         // Use per-agent timer to handle multiple agents speaking simultaneously
-        var existingTimer = speakingExpiryTimers.get(agentId);
+        const existingTimer = speakingExpiryTimers.get(agentId);
         if (existingTimer) clearTimeout(existingTimer);
         speakingExpiryTimers.set(agentId, setTimeout(function() {
           speakingExpiryTimers.delete(agentId);
@@ -279,6 +279,12 @@ export function getSseClientScript(): string {
         if (agent.currentSpaceId === spaceId) {
           agent.currentSpaceId = null;
           agent.currentSpaceName = null;
+        }
+        // Clear any pending speaking timer for this agent
+        const leftTimer = speakingExpiryTimers.get(agentId);
+        if (leftTimer) {
+          clearTimeout(leftTimer);
+          speakingExpiryTimers.delete(agentId);
         }
       } else if (action === 'match') {
         agent.experience += XP_VALUES.match || 0;

--- a/src/proofportal/sse-client.ts
+++ b/src/proofportal/sse-client.ts
@@ -48,6 +48,7 @@ export function getSseClientScript(): string {
   // Guild thresholds (Phase 5)
   const SPEAKING_THRESHOLD_MS = 10000;  // 10 seconds for 'speaking' state
   const ACTIVE_THRESHOLD_MS = 60000;    // 60 seconds for 'active' state
+  const SPEAKING_EXPIRY_BUFFER_MS = 100; // Buffer to ensure state change before re-render
 
   // XP values per action
   // IMPORTANT: Keep in sync with applyEvent() in src/proofportal/types.ts
@@ -273,7 +274,7 @@ export function getSseClientScript(): string {
           speakingExpiryTimers.delete(agentId);
           renderGuildPanel();
           renderGuildMap();
-        }, SPEAKING_THRESHOLD_MS + 100)); // Small buffer to ensure state change
+        }, SPEAKING_THRESHOLD_MS + SPEAKING_EXPIRY_BUFFER_MS));
       } else if (action === 'left' && spaceId) {
         if (agent.currentSpaceId === spaceId) {
           agent.currentSpaceId = null;

--- a/src/proofportal/templates/components/GuildMap.ts
+++ b/src/proofportal/templates/components/GuildMap.ts
@@ -283,6 +283,21 @@ export function getGuildMapStyles(): string {
       }
     }
 
+    @keyframes bubbleFadeOutMap {
+      from {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+      }
+      to {
+        opacity: 0;
+        transform: translateX(-50%) translateY(-10px);
+      }
+    }
+
+    .guild-map-bubble.bubble-leaving {
+      animation: bubbleFadeOutMap 0.3s ease-out forwards;
+    }
+
     .guild-map-bubble::after {
       content: '';
       position: absolute;

--- a/src/proofportal/templates/components/GuildMap.ts
+++ b/src/proofportal/templates/components/GuildMap.ts
@@ -269,10 +269,10 @@ export function getGuildMapStyles(): string {
       text-overflow: ellipsis;
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
       z-index: 10;
-      animation: bubbleAppear 0.3s ease-out;
+      animation: bubbleAppearMap 0.3s ease-out;
     }
 
-    @keyframes bubbleAppear {
+    @keyframes bubbleAppearMap {
       from {
         opacity: 0;
         transform: translateX(-50%) translateY(10px);

--- a/src/proofportal/templates/components/GuildMap.ts
+++ b/src/proofportal/templates/components/GuildMap.ts
@@ -269,6 +269,18 @@ export function getGuildMapStyles(): string {
       text-overflow: ellipsis;
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
       z-index: 10;
+      animation: bubbleAppear 0.3s ease-out;
+    }
+
+    @keyframes bubbleAppear {
+      from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+      }
     }
 
     .guild-map-bubble::after {

--- a/src/proofportal/templates/components/GuildPanel.ts
+++ b/src/proofportal/templates/components/GuildPanel.ts
@@ -74,6 +74,7 @@ export function renderGuildMemberCard(member: GuildMemberDisplayData): string {
   const initial = member.name.charAt(0).toUpperCase();
   const displayId = truncateGuildId(member.agentId);
   const statusClass = member.membershipStatus;
+  const isSpeaking = member.visualState === 'speaking';
 
   return `
     <div class="guild-member ${getVisualStateClass(member.visualState)}" data-agent-id="${escapeHtml(member.agentId)}">
@@ -86,7 +87,7 @@ export function renderGuildMemberCard(member: GuildMemberDisplayData): string {
         </div>
         <div class="guild-member-id" title="${escapeHtml(member.agentId)}">${escapeHtml(displayId)}</div>
       </div>
-      ${member.lastMessagePreview ? `<div class="guild-member-bubble">${escapeHtml(member.lastMessagePreview)}</div>` : ''}
+      ${isSpeaking && member.lastMessagePreview ? `<div class="guild-member-bubble">${escapeHtml(member.lastMessagePreview)}</div>` : ''}
     </div>
   `;
 }
@@ -250,6 +251,18 @@ export function getGuildPanelStyles(): string {
       overflow: hidden;
       text-overflow: ellipsis;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+      animation: bubbleAppear 0.3s ease-out;
+    }
+
+    @keyframes bubbleAppear {
+      from {
+        opacity: 0;
+        transform: translateY(5px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
     }
 
     .guild-member.visual-state-speaking .guild-member-bubble {

--- a/src/proofportal/templates/components/GuildPanel.ts
+++ b/src/proofportal/templates/components/GuildPanel.ts
@@ -251,10 +251,10 @@ export function getGuildPanelStyles(): string {
       overflow: hidden;
       text-overflow: ellipsis;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-      animation: bubbleAppear 0.3s ease-out;
+      animation: bubbleAppearPanel 0.3s ease-out;
     }
 
-    @keyframes bubbleAppear {
+    @keyframes bubbleAppearPanel {
       from {
         opacity: 0;
         transform: translateY(5px);

--- a/src/proofportal/templates/components/GuildPanel.ts
+++ b/src/proofportal/templates/components/GuildPanel.ts
@@ -265,6 +265,21 @@ export function getGuildPanelStyles(): string {
       }
     }
 
+    @keyframes bubbleFadeOutPanel {
+      from {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      to {
+        opacity: 0;
+        transform: translateY(-5px);
+      }
+    }
+
+    .guild-member-bubble.bubble-leaving {
+      animation: bubbleFadeOutPanel 0.3s ease-out forwards;
+    }
+
     .guild-member.visual-state-speaking .guild-member-bubble {
       background: var(--accent-green);
       color: white;


### PR DESCRIPTION
## Summary

Broadcast 時に Portal 上でメッセージの吹き出しを表示する機能を実装。

- SSE クライアントで speaking 状態の有効期限タイマーを追加
- 吹き出しの appear アニメーション追加（フェードイン + スライドアップ）
- 既存の visualState ロジックが 'speaking' 状態を処理

## 変更内容

| ファイル | 変更 |
|---------|------|
| `src/proofportal/sse-client.ts` | speaking 状態有効期限後の再レンダリングタイマー |
| `src/proofportal/templates/components/GuildMap.ts` | 吹き出しアニメーション CSS |

## 動作

1. `proofcomm_space` イベント (`action: 'message'`) を受信
2. `visualState` が `speaking` に変更（10秒間）
3. アバター上に吹き出しを表示
4. 10秒後に自動的に非表示

Closes #133

🤖 Generated with [Claude Code](https://claude.ai/claude-code)