### PR TITLE
feat(proofguild): A2A message dispatch to space members

### DIFF
--- a/docs/proofguild-roadmap.md
+++ b/docs/proofguild-roadmap.md
@@ -228,7 +228,7 @@ proofscan は全 A2A 通信の中継者として:
 ```
 Phase 5:   [##########] 完了 - Guild 基盤
 Phase 5.1: [##########] 完了 - Broadcast API
-Phase 5.2: [          ] 未着手 - A2A Dispatch
+Phase 5.2: [########  ] 進行中 - A2A Dispatch (dispatch実装完了、統合テスト未)
 Phase 5.3: [          ] 未着手 - Token 永続化
 Phase 5.4: [          ] 計画 - 通信監視
 Phase 6:   [          ] 計画 - 高度な機能

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -1334,21 +1334,28 @@ export function registerProofCommRoutes(
     const spaceName = space?.name ?? space_id;
 
     // A2A dispatch function - sends message to each recipient agent via JSON-RPC
-    // Note: A2AClient is stateless (no persistent connections), so creating per-dispatch is fine
+    // IMPORTANT: This closure captures request-scoped values (space_id, agentId, spaceName).
+    // It is created fresh per-request and must NOT be reused across requests.
+    // A2AClient is stateless (uses fetch internally, no connection pooling) - see A2AClient.sendMessage()
     const dispatchToAgent: DispatchToAgentFn = async (targetAgentId, message) => {
       try {
         // Look up target agent's URL from targets store
         const target = targetsStore.get(targetAgentId);
         if (!target) {
-          return { success: false, error: `Agent not found: ${targetAgentId}` };
+          request.log.debug({ targetAgentId }, 'A2A dispatch: agent not found');
+          return { success: false, error: 'Agent not found' };
         }
 
         // Guild-registered agents store config as { url, source, registered_at, ... }
         // Type assertion is safe because we check url existence below
         const config = target.config as { url?: string; allow_local?: boolean } | undefined;
         if (!config?.url) {
-          return { success: false, error: `Agent has no URL configured: ${targetAgentId}` };
+          request.log.debug({ targetAgentId }, 'A2A dispatch: agent has no URL');
+          return { success: false, error: 'Agent configuration invalid' };
         }
+
+        // Validate allow_local is boolean if present (defense against config corruption)
+        const allowLocal = typeof config.allow_local === 'boolean' ? config.allow_local : false;
 
         // Check cache for AgentCard
         // Note: Concurrent requests may race on cache-miss and fetch multiple times;
@@ -1366,20 +1373,23 @@ export function registerProofCommRoutes(
           // If parse fails, treat as cache miss and fetch fresh
         }
 
-        // Fetch AgentCard if not cached, invalid, or expired
-        if (!agentCard || (cached?.expiresAt && new Date(cached.expiresAt) < now)) {
+        // Fetch AgentCard if not cached, invalid, expired, or missing expiry
+        // (missing expiresAt is treated as expired to ensure we always have a TTL)
+        const isExpired = !cached?.expiresAt || new Date(cached.expiresAt) < now;
+        if (!agentCard || isExpired) {
           const fetchResult = await fetchAgentCard(config.url, {
-            allowLocal: config.allow_local ?? false,
+            allowLocal,
             timeout: AGENT_CARD_FETCH_TIMEOUT_MS,
           });
 
           if (!fetchResult.ok || !fetchResult.agentCard) {
-            return { success: false, error: `Failed to fetch AgentCard: ${fetchResult.error}` };
+            request.log.debug({ targetAgentId, error: fetchResult.error }, 'A2A dispatch: AgentCard fetch failed');
+            return { success: false, error: 'Failed to fetch agent metadata' };
           }
 
           agentCard = fetchResult.agentCard;
 
-          // Update cache
+          // Update cache (always set expiresAt to ensure TTL enforcement)
           agentCacheStore.set({
             targetId: targetAgentId,
             agentCard,
@@ -1390,7 +1400,7 @@ export function registerProofCommRoutes(
         }
 
         // Create A2AClient and send message
-        const client = new A2AClient(agentCard, { allowLocal: config.allow_local ?? false });
+        const client = new A2AClient(agentCard, { allowLocal });
 
         // Enrich message metadata with space info
         const enrichedMessage: A2AMessage = {
@@ -1406,7 +1416,8 @@ export function registerProofCommRoutes(
         const sendResult = await client.sendMessage(enrichedMessage, { timeout: MESSAGE_SEND_TIMEOUT_MS });
 
         if (!sendResult.ok) {
-          return { success: false, error: sendResult.error ?? 'Send failed' };
+          request.log.debug({ targetAgentId, error: sendResult.error }, 'A2A dispatch: send failed');
+          return { success: false, error: 'Message delivery failed' };
         }
 
         request.log.debug({ targetAgentId, spaceId: space_id }, 'A2A dispatch succeeded');
@@ -1414,7 +1425,8 @@ export function registerProofCommRoutes(
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
         request.log.warn({ targetAgentId, error: errorMessage }, 'A2A dispatch failed');
-        return { success: false, error: errorMessage };
+        // Return generic error to caller, detailed error is logged above
+        return { success: false, error: 'Dispatch failed' };
       }
     };
 

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -1337,12 +1337,17 @@ export function registerProofCommRoutes(
     // IMPORTANT: This closure captures request-scoped values (space_id, agentId, spaceName).
     // It is created fresh per-request and must NOT be reused across requests.
     // A2AClient is stateless (uses fetch internally, no connection pooling) - see A2AClient.sendMessage()
+    //
+    // Partial failure semantics: If dispatch fails for some recipients, broadcastToSpace
+    // continues dispatching to remaining recipients and aggregates results. The broadcast
+    // API returns { delivered, failed, recipient_count } so callers can see partial failures.
+    // Individual failures are logged here at warn level for operator visibility.
     const dispatchToAgent: DispatchToAgentFn = async (targetAgentId, message) => {
       try {
         // Look up target agent's URL from targets store
         const target = targetsStore.get(targetAgentId);
         if (!target) {
-          request.log.debug({ targetAgentId }, 'A2A dispatch: agent not found');
+          request.log.warn({ targetAgentId, spaceId: space_id }, 'A2A dispatch: agent not found');
           return { success: false, error: 'Agent not found' };
         }
 
@@ -1350,7 +1355,7 @@ export function registerProofCommRoutes(
         // Type assertion is safe because we check url existence below
         const config = target.config as { url?: string; allow_local?: boolean } | undefined;
         if (!config?.url) {
-          request.log.debug({ targetAgentId }, 'A2A dispatch: agent has no URL');
+          request.log.warn({ targetAgentId, spaceId: space_id }, 'A2A dispatch: agent has no URL');
           return { success: false, error: 'Agent configuration invalid' };
         }
 
@@ -1383,7 +1388,7 @@ export function registerProofCommRoutes(
           });
 
           if (!fetchResult.ok || !fetchResult.agentCard) {
-            request.log.debug({ targetAgentId, error: fetchResult.error }, 'A2A dispatch: AgentCard fetch failed');
+            request.log.warn({ targetAgentId, spaceId: space_id, error: fetchResult.error }, 'A2A dispatch: AgentCard fetch failed');
             return { success: false, error: 'Failed to fetch agent metadata' };
           }
 
@@ -1416,7 +1421,7 @@ export function registerProofCommRoutes(
         const sendResult = await client.sendMessage(enrichedMessage, { timeout: MESSAGE_SEND_TIMEOUT_MS });
 
         if (!sendResult.ok) {
-          request.log.debug({ targetAgentId, error: sendResult.error }, 'A2A dispatch: send failed');
+          request.log.warn({ targetAgentId, spaceId: space_id, error: sendResult.error }, 'A2A dispatch: send failed');
           return { success: false, error: 'Message delivery failed' };
         }
 

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -1353,15 +1353,26 @@ export function registerProofCommRoutes(
 
         // Validate config shape at runtime (guards against DB corruption or schema changes)
         const config = target.config;
-        if (!config || typeof config !== 'object' || !('url' in config) || typeof config.url !== 'string' || !config.url) {
+        const hasValidUrl =
+          config &&
+          typeof config === 'object' &&
+          'url' in config &&
+          typeof config.url === 'string' &&
+          config.url;
+
+        if (!hasValidUrl) {
           request.log.warn({ targetAgentId, spaceId: space_id }, 'A2A dispatch: agent has invalid config');
           return { success: false, error: 'Agent configuration invalid' };
         }
 
+        // Extract validated URL (TypeScript needs explicit narrowing after the guard)
+        const agentUrl = config.url as string;
+
         // Validate allow_local is boolean if present (defense against config corruption)
-        const allowLocal = 'allow_local' in config && typeof config.allow_local === 'boolean'
-          ? config.allow_local
-          : false;
+        const allowLocal =
+          'allow_local' in config && typeof config.allow_local === 'boolean'
+            ? config.allow_local
+            : false;
 
         // Check cache for AgentCard
         // Note: Concurrent requests may race on cache-miss and fetch multiple times;
@@ -1386,31 +1397,44 @@ export function registerProofCommRoutes(
         if (needsFetch) {
           // SSRF protection: fetchAgentCard validates URLs against private IP ranges
           // and enforces allowLocal=false by default. See src/a2a/agent-card.ts isPrivateUrl()
-          const fetchResult = await fetchAgentCard(config.url, {
+          const fetchResult = await fetchAgentCard(agentUrl, {
             allowLocal,
             timeout: AGENT_CARD_FETCH_TIMEOUT_MS,
           });
 
           if (!fetchResult.ok || !fetchResult.agentCard) {
-            request.log.warn({ targetAgentId, spaceId: space_id, error: fetchResult.error }, 'A2A dispatch: AgentCard fetch failed');
-            return { success: false, error: 'Failed to fetch agent metadata' };
+            // Stale-while-error: if we have a valid but expired card, use it rather than failing
+            if (agentCard) {
+              request.log.warn(
+                { targetAgentId, spaceId: space_id, error: fetchResult.error },
+                'A2A dispatch: AgentCard fetch failed, using stale cache'
+              );
+              // Continue with stale agentCard (don't update cache with failure)
+            } else {
+              request.log.warn(
+                { targetAgentId, spaceId: space_id, error: fetchResult.error },
+                'A2A dispatch: AgentCard fetch failed'
+              );
+              return { success: false, error: 'Failed to fetch agent metadata' };
+            }
+          } else {
+            agentCard = fetchResult.agentCard;
+
+            // Update cache (always set expiresAt to ensure TTL enforcement)
+            agentCacheStore.set({
+              targetId: targetAgentId,
+              agentCard,
+              agentCardHash: fetchResult.hash,
+              fetchedAt: now.toISOString(),
+              expiresAt: new Date(now.getTime() + AGENT_CARD_CACHE_TTL_MS).toISOString(),
+            });
           }
-
-          agentCard = fetchResult.agentCard;
-
-          // Update cache (always set expiresAt to ensure TTL enforcement)
-          agentCacheStore.set({
-            targetId: targetAgentId,
-            agentCard,
-            agentCardHash: fetchResult.hash,
-            fetchedAt: now.toISOString(),
-            expiresAt: new Date(now.getTime() + AGENT_CARD_CACHE_TTL_MS).toISOString(),
-          });
         }
 
         // At this point agentCard is guaranteed to be defined:
-        // - Either from valid cache (needsFetch was false)
-        // - Or from successful fetch (we return early on failure)
+        // - From valid cache (needsFetch was false)
+        // - From successful fetch
+        // - From stale cache on fetch failure (stale-while-error)
         if (!agentCard) {
           // This should never happen, but guard for type safety
           request.log.error({ targetAgentId, spaceId: space_id }, 'A2A dispatch: unexpected undefined agentCard');
@@ -1442,7 +1466,7 @@ export function registerProofCommRoutes(
         return { success: true };
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
-        request.log.warn({ targetAgentId, error: errorMessage }, 'A2A dispatch failed');
+        request.log.warn({ targetAgentId, spaceId: space_id, error: errorMessage }, 'A2A dispatch failed');
         // Return generic error to caller, detailed error is logged above
         return { success: false, error: 'Dispatch failed' };
       }

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -38,6 +38,10 @@ import {
   type GuildRegisterRequest,
 } from '../proofcomm/guild/index.js';
 import type { A2AMessage } from '../db/types.js';
+import { A2AClient } from '../a2a/client.js';
+import { fetchAgentCard } from '../a2a/agent-card.js';
+import type { AgentCard } from '../a2a/types.js';
+import { AgentCacheStore } from '../db/agent-cache-store.js';
 
 /**
  * Document registration request body
@@ -122,6 +126,7 @@ export function registerProofCommRoutes(
   const skillsStore = new SkillsStore(options.configDir);
   const skillRegistry = new SkillRegistry(skillsStore);
   const targetsStore = new TargetsStore(options.configDir);
+  const agentCacheStore = new AgentCacheStore(options.configDir);
   const spacesStore = new SpacesStore(options.configDir);
   const spaceManager = new SpaceManager(spacesStore, options.auditLogger);
 
@@ -1317,12 +1322,78 @@ export function registerProofCommRoutes(
       },
     };
 
-    // Create a stub dispatch function for Phase 5.1
-    // Phase 5.1: Event is emitted by broadcastToSpace, but no actual A2A dispatch yet
-    // Returns success: true because the broadcast operation itself succeeded (message queued)
-    // Phase 5.2 will implement actual A2A JSON-RPC dispatch to each recipient
-    const stubDispatch: DispatchToAgentFn = async (_targetAgentId, _message) => {
-      return { success: true };
+    // Get space info for metadata enrichment
+    const space = spaceManager.getSpace(space_id);
+    const spaceName = space?.name ?? space_id;
+
+    // A2A dispatch function - sends message to each recipient agent via JSON-RPC
+    const dispatchToAgent: DispatchToAgentFn = async (targetAgentId, message) => {
+      try {
+        // Look up target agent's URL from targets store
+        const target = targetsStore.get(targetAgentId);
+        if (!target) {
+          return { success: false, error: `Agent not found: ${targetAgentId}` };
+        }
+
+        const config = target.config as { url?: string; allow_local?: boolean } | undefined;
+        if (!config?.url) {
+          return { success: false, error: `Agent has no URL configured: ${targetAgentId}` };
+        }
+
+        // Check cache for AgentCard
+        const cached = agentCacheStore.get(targetAgentId);
+        const now = new Date();
+        let agentCard = cached?.agentCard as AgentCard | undefined;
+
+        // Fetch AgentCard if not cached or expired
+        if (!agentCard || (cached?.expiresAt && new Date(cached.expiresAt) < now)) {
+          const fetchResult = await fetchAgentCard(config.url, {
+            allowLocal: config.allow_local ?? false,
+            timeout: 10_000,
+          });
+
+          if (!fetchResult.ok || !fetchResult.agentCard) {
+            return { success: false, error: `Failed to fetch AgentCard: ${fetchResult.error}` };
+          }
+
+          agentCard = fetchResult.agentCard;
+
+          // Update cache (1 hour TTL)
+          agentCacheStore.set({
+            targetId: targetAgentId,
+            agentCard,
+            agentCardHash: fetchResult.hash,
+            fetchedAt: now.toISOString(),
+            expiresAt: new Date(now.getTime() + 3600_000).toISOString(),
+          });
+        }
+
+        // Create A2AClient and send message
+        const client = new A2AClient(agentCard, { allowLocal: config.allow_local ?? false });
+
+        // Enrich message metadata with space info
+        const enrichedMessage: A2AMessage = {
+          ...message,
+          metadata: {
+            ...message.metadata,
+            space_id,
+            space_name: spaceName,
+            sender_agent_id: agentId,
+          },
+        };
+
+        const sendResult = await client.sendMessage(enrichedMessage, { timeout: 30_000 });
+
+        if (!sendResult.ok) {
+          return { success: false, error: sendResult.error ?? 'Send failed' };
+        }
+
+        return { success: true };
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        request.log.warn({ targetAgentId, error: errorMessage }, 'A2A dispatch failed');
+        return { success: false, error: errorMessage };
+      }
     };
 
     const result = await spaceManager.broadcastToSpace(
@@ -1331,7 +1402,7 @@ export function registerProofCommRoutes(
         senderAgentId: agentId,
         message: a2aMessage,
       },
-      stubDispatch,
+      dispatchToAgent,
       {
         requestId: request.requestId,
         traceId: request.headers['x-trace-id'] as string | undefined,

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -1351,16 +1351,17 @@ export function registerProofCommRoutes(
           return { success: false, error: 'Agent not found' };
         }
 
-        // Guild-registered agents store config as { url, source, registered_at, ... }
-        // Type assertion is safe because we check url existence below
-        const config = target.config as { url?: string; allow_local?: boolean } | undefined;
-        if (!config?.url) {
-          request.log.warn({ targetAgentId, spaceId: space_id }, 'A2A dispatch: agent has no URL');
+        // Validate config shape at runtime (guards against DB corruption or schema changes)
+        const config = target.config;
+        if (!config || typeof config !== 'object' || !('url' in config) || typeof config.url !== 'string' || !config.url) {
+          request.log.warn({ targetAgentId, spaceId: space_id }, 'A2A dispatch: agent has invalid config');
           return { success: false, error: 'Agent configuration invalid' };
         }
 
         // Validate allow_local is boolean if present (defense against config corruption)
-        const allowLocal = typeof config.allow_local === 'boolean' ? config.allow_local : false;
+        const allowLocal = 'allow_local' in config && typeof config.allow_local === 'boolean'
+          ? config.allow_local
+          : false;
 
         // Check cache for AgentCard
         // Note: Concurrent requests may race on cache-miss and fetch multiple times;
@@ -1378,10 +1379,13 @@ export function registerProofCommRoutes(
           // If parse fails, treat as cache miss and fetch fresh
         }
 
-        // Fetch AgentCard if not cached, invalid, expired, or missing expiry
-        // (missing expiresAt is treated as expired to ensure we always have a TTL)
+        // Determine if we need to fetch: no valid card, expired, or missing expiry timestamp
         const isExpired = !cached?.expiresAt || new Date(cached.expiresAt) < now;
-        if (!agentCard || isExpired) {
+        const needsFetch = !agentCard || isExpired;
+
+        if (needsFetch) {
+          // SSRF protection: fetchAgentCard validates URLs against private IP ranges
+          // and enforces allowLocal=false by default. See src/a2a/agent-card.ts isPrivateUrl()
           const fetchResult = await fetchAgentCard(config.url, {
             allowLocal,
             timeout: AGENT_CARD_FETCH_TIMEOUT_MS,
@@ -1402,6 +1406,15 @@ export function registerProofCommRoutes(
             fetchedAt: now.toISOString(),
             expiresAt: new Date(now.getTime() + AGENT_CARD_CACHE_TTL_MS).toISOString(),
           });
+        }
+
+        // At this point agentCard is guaranteed to be defined:
+        // - Either from valid cache (needsFetch was false)
+        // - Or from successful fetch (we return early on failure)
+        if (!agentCard) {
+          // This should never happen, but guard for type safety
+          request.log.error({ targetAgentId, spaceId: space_id }, 'A2A dispatch: unexpected undefined agentCard');
+          return { success: false, error: 'Internal error' };
         }
 
         // Create A2AClient and send message

--- a/src/gateway/proofcommProxy.ts
+++ b/src/gateway/proofcommProxy.ts
@@ -40,8 +40,14 @@ import {
 import type { A2AMessage } from '../db/types.js';
 import { A2AClient } from '../a2a/client.js';
 import { fetchAgentCard } from '../a2a/agent-card.js';
+import { parseAgentCard } from '../a2a/config.js';
 import type { AgentCard } from '../a2a/types.js';
 import { AgentCacheStore } from '../db/agent-cache-store.js';
+
+// Dispatch timeout constants
+const AGENT_CARD_FETCH_TIMEOUT_MS = 10_000;
+const MESSAGE_SEND_TIMEOUT_MS = 30_000;
+const AGENT_CARD_CACHE_TTL_MS = 3600_000; // 1 hour
 
 /**
  * Document registration request body
@@ -1323,10 +1329,12 @@ export function registerProofCommRoutes(
     };
 
     // Get space info for metadata enrichment
+    // Fallback to space_id if space was deleted between validation and dispatch (rare edge case)
     const space = spaceManager.getSpace(space_id);
     const spaceName = space?.name ?? space_id;
 
     // A2A dispatch function - sends message to each recipient agent via JSON-RPC
+    // Note: A2AClient is stateless (no persistent connections), so creating per-dispatch is fine
     const dispatchToAgent: DispatchToAgentFn = async (targetAgentId, message) => {
       try {
         // Look up target agent's URL from targets store
@@ -1335,21 +1343,34 @@ export function registerProofCommRoutes(
           return { success: false, error: `Agent not found: ${targetAgentId}` };
         }
 
+        // Guild-registered agents store config as { url, source, registered_at, ... }
+        // Type assertion is safe because we check url existence below
         const config = target.config as { url?: string; allow_local?: boolean } | undefined;
         if (!config?.url) {
           return { success: false, error: `Agent has no URL configured: ${targetAgentId}` };
         }
 
         // Check cache for AgentCard
+        // Note: Concurrent requests may race on cache-miss and fetch multiple times;
+        // this is acceptable (last-write-wins) as it only wastes bandwidth, not correctness
         const cached = agentCacheStore.get(targetAgentId);
         const now = new Date();
-        let agentCard = cached?.agentCard as AgentCard | undefined;
 
-        // Fetch AgentCard if not cached or expired
+        // Validate cached AgentCard shape (guards against stale/corrupted cache)
+        let agentCard: AgentCard | undefined;
+        if (cached?.agentCard) {
+          const parseResult = parseAgentCard(cached.agentCard);
+          if (parseResult.ok) {
+            agentCard = parseResult.value;
+          }
+          // If parse fails, treat as cache miss and fetch fresh
+        }
+
+        // Fetch AgentCard if not cached, invalid, or expired
         if (!agentCard || (cached?.expiresAt && new Date(cached.expiresAt) < now)) {
           const fetchResult = await fetchAgentCard(config.url, {
             allowLocal: config.allow_local ?? false,
-            timeout: 10_000,
+            timeout: AGENT_CARD_FETCH_TIMEOUT_MS,
           });
 
           if (!fetchResult.ok || !fetchResult.agentCard) {
@@ -1358,13 +1379,13 @@ export function registerProofCommRoutes(
 
           agentCard = fetchResult.agentCard;
 
-          // Update cache (1 hour TTL)
+          // Update cache
           agentCacheStore.set({
             targetId: targetAgentId,
             agentCard,
             agentCardHash: fetchResult.hash,
             fetchedAt: now.toISOString(),
-            expiresAt: new Date(now.getTime() + 3600_000).toISOString(),
+            expiresAt: new Date(now.getTime() + AGENT_CARD_CACHE_TTL_MS).toISOString(),
           });
         }
 
@@ -1382,12 +1403,13 @@ export function registerProofCommRoutes(
           },
         };
 
-        const sendResult = await client.sendMessage(enrichedMessage, { timeout: 30_000 });
+        const sendResult = await client.sendMessage(enrichedMessage, { timeout: MESSAGE_SEND_TIMEOUT_MS });
 
         if (!sendResult.ok) {
           return { success: false, error: sendResult.error ?? 'Send failed' };
         }
 
+        request.log.debug({ targetAgentId, spaceId: space_id }, 'A2A dispatch succeeded');
         return { success: true };
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

- Implement real A2A JSON-RPC dispatch to space members on broadcast
- Replace stub dispatch function with A2AClient-based implementation
- Lookup target agent URL from TargetsStore, fetch/cache AgentCard
- Enrich message metadata with space_id, space_name, sender_agent_id

## Changes

- `src/gateway/proofcommProxy.ts`: Real dispatch implementation
- `docs/proofguild-roadmap.md`: Phase 5.2 progress update

## Test plan

- [x] All existing tests pass (2485 tests)
- [ ] Manual test with OpenClaw agent (integration test)

Closes #134

🤖 Generated with [Claude Code](https://claude.ai/claude-code)